### PR TITLE
Adding test cases for analytics adapter

### DIFF
--- a/modules/pubmaticAnalyticsAdapter.js
+++ b/modules/pubmaticAnalyticsAdapter.js
@@ -360,7 +360,10 @@ const eventHandlers = {
   },
 
   bidderDone: (args)=> {
-    cache.auctions[args.auctionId].bidderDonePendingCount--;
+   
+    if(cache.auctions[args.auctionId]?.bidderDonePendingCount){
+      cache.auctions[args.auctionId].bidderDonePendingCount--;
+    }
     args.bids.forEach(bid => {
       let cachedBid = cache.auctions[bid.auctionId].adUnitCodes[bid.adUnitCode].bids[bid.bidId || bid.originalRequestId || bid.requestId];
       if (typeof bid.serverResponseTimeMs !== 'undefined') {

--- a/test/spec/modules/pubmaticAnalyticsAdapter_spec.js
+++ b/test/spec/modules/pubmaticAnalyticsAdapter_spec.js
@@ -5,7 +5,6 @@ import { config } from 'src/config.js';
 import { setConfig } from 'modules/currency.js';
 import { server } from '../../mocks/xhr.js';
 import 'src/prebid.js';
-import { getGlobal } from 'src/prebidGlobal';
 
 let events = require('src/events');
 let ajax = require('src/ajax');
@@ -69,14 +68,11 @@ const BID = {
   },
   'floorData': {
     'cpmAfterAdjustments': 6.3,
-    'enforcements': {'enforceJS': true, 'enforcePBS': false, 'floorDeals': false, 'bidAdjustment': true},
+    'enforcements': { 'enforceJS': true, 'enforcePBS': false, 'floorDeals': false, 'bidAdjustment': true },
     'floorCurrency': 'USD',
     'floorRule': 'banner',
     'floorRuleValue': 1.1,
     'floorValue': 1.1
-  },
-  'meta': {
-    'demandSource': 1208,
   },
   getStatusCode() {
     return 1;
@@ -106,11 +102,9 @@ const BID2 = Object.assign({}, BID, {
     'hb_source': 'server'
   },
   meta: {
-    advertiserDomains: ['example.com'],
-    'demandSource': 1208,
+    advertiserDomains: ['example.com']
   }
 });
-
 const BID3 = Object.assign({}, BID2, {
   rejectionReason: REJECTION_REASON.FLOOR_NOT_MET
 })
@@ -123,24 +117,24 @@ const MOCK = {
     'auctionId': '25c6d7f5-699a-4bfc-87c9-996f915341fa',
     'timestamp': 1519767010567,
     'auctionStatus': 'inProgress',
-    'adUnits': [ {
+    'adUnits': [{
       'code': '/19968336/header-bid-tag-1',
       'sizes': [[640, 480]],
-      'bids': [ {
+      'bids': [{
         'bidder': 'pubmatic',
         'params': {
           'publisherId': '1001'
         }
-      } ],
+      }],
       'transactionId': 'ca4af27a-6d02-4f90-949d-d5541fa12014'
     }
     ],
     'adUnitCodes': ['/19968336/header-bid-tag-1'],
-    'bidderRequests': [ {
+    'bidderRequests': [{
       'bidderCode': 'pubmatic',
       'auctionId': '25c6d7f5-699a-4bfc-87c9-996f915341fa',
       'bidderRequestId': '1be65d7958826a',
-      'bids': [ {
+      'bids': [{
         'bidder': 'pubmatic',
         'params': {
           'publisherId': '1001',
@@ -277,7 +271,7 @@ const MOCK = {
 };
 
 function getLoggerJsonFromRequest(requestBody) {
-  return JSON.parse(decodeURIComponent(requestBody.split('json=')[1]));
+  return JSON.parse(decodeURIComponent(requestBody));
 }
 
 describe('pubmatic analytics adapter', function () {
@@ -318,8 +312,8 @@ describe('pubmatic analytics adapter', function () {
     expect(utils.logError.called).to.equal(true);
   });
 
-  describe('OW S2S', function() {
-    this.beforeEach(function() {
+  describe('OW S2S', function () {
+    this.beforeEach(function () {
       pubmaticAnalyticsAdapter.enableAnalytics({
         options: {
           publisherId: 9999,
@@ -337,11 +331,11 @@ describe('pubmatic analytics adapter', function () {
       });
     });
 
-    this.afterEach(function() {
+    this.afterEach(function () {
       pubmaticAnalyticsAdapter.disableAnalytics();
     });
-
-    it('Pubmatic Won: No tracker fired', function() {
+   
+    it('Pubmatic Won: No tracker fired', function () {
       this.timeout(5000)
 
       sandbox.stub($$PREBID_GLOBAL$$, 'getHighestCpmBids').callsFake((key) => {
@@ -363,14 +357,19 @@ describe('pubmatic analytics adapter', function () {
       clock.tick(2000 + 1000);
       expect(requests.length).to.equal(1); // only logger is fired
       let request = requests[0];
-      expect(request.url).to.equal('https://t.pubmatic.com/wl?pubid=9999');
+      expect(request.url).to.equal('https://t.pubmatic.com/wl?v=1&psrc=web');
       let data = getLoggerJsonFromRequest(request.requestBody);
-      expect(data.pubid).to.equal('9999');
-      expect(data.pid).to.equal('1111');
-      expect(data.pdvid).to.equal('20');
+      // check mandatory fields
+      expect(data).to.have.property('sd');
+      expect(data).to.have.property('fd');
+      expect(data).to.have.property('rd');
+
+      expect(data.rd.pubid).to.equal('9999');
+      expect(data.rd.pid).to.equal('1111');
+      expect(data.rd.pdvid).to.equal('20');
     });
 
-    it('Non-pubmatic won: logger, tracker fired', function() {
+    it('Non-pubmatic won: logger, tracker fired', function () {
       const APPNEXUS_BID = Object.assign({}, BID, {
         'bidder': 'appnexus',
         'adserverTargeting': {
@@ -386,24 +385,24 @@ describe('pubmatic analytics adapter', function () {
         'auctionId': '25c6d7f5-699a-4bfc-87c9-996f915341fa',
         'timestamp': 1519767010567,
         'auctionStatus': 'inProgress',
-        'adUnits': [ {
+        'adUnits': [{
           'code': '/19968336/header-bid-tag-1',
           'sizes': [[640, 480]],
-          'bids': [ {
+          'bids': [{
             'bidder': 'appnexus',
             'params': {
               'publisherId': '1001'
             }
-          } ],
+          }],
           'transactionId': 'ca4af27a-6d02-4f90-949d-d5541fa12014'
         }
         ],
         'adUnitCodes': ['/19968336/header-bid-tag-1'],
-        'bidderRequests': [ {
+        'bidderRequests': [{
           'bidderCode': 'appnexus',
           'auctionId': '25c6d7f5-699a-4bfc-87c9-996f915341fa',
           'bidderRequestId': '1be65d7958826a',
-          'bids': [ {
+          'bids': [{
             'bidder': 'appnexus',
             'params': {
               'publisherId': '1001',
@@ -501,26 +500,32 @@ describe('pubmatic analytics adapter', function () {
       clock.tick(2000 + 1000);
       expect(requests.length).to.equal(2); // logger as well as tracker is fired
       let request = requests[1]; // logger is executed late, trackers execute first
-      expect(request.url).to.equal('https://t.pubmatic.com/wl?pubid=9999');
+      expect(request.url).to.equal('https://t.pubmatic.com/wl?v=1&psrc=web');
       let data = getLoggerJsonFromRequest(request.requestBody);
-      expect(data.pubid).to.equal('9999');
-      expect(data.pid).to.equal('1111');
-      expect(data.pdvid).to.equal('20');
+
+      // check mandatory fields
+      expect(data).to.have.property('sd');
+      expect(data).to.have.property('fd');
+      expect(data).to.have.property('rd');
+
+      expect(data.rd.pubid).to.equal('9999');
+      expect(data.rd.pid).to.equal('1111');
+      expect(data.rd.pdvid).to.equal('20');
+
+      expect(data.sd).to.be.an('object');
+      expect(Object.keys(data.sd).length).to.equal(1);
+      expect(data.sd['/19968336/header-bid-tag-0'].bids['2ecff0db240757'][0].adapterCode).to.equal('appnexus');
+      expect(data.sd['/19968336/header-bid-tag-0'].bids['2ecff0db240757'][0].bidderCode).to.equal('appnexus');
 
       let firstTracker = requests[0].url;
       expect(firstTracker.split('?')[0]).to.equal('https://t.pubmatic.com/wt');
       firstTracker.split('?')[1].split('&').map(e => e.split('=')).forEach(e => data[e[0]] = e[1]);
-      expect(data.pubid).to.equal('9999');
-      expect(decodeURIComponent(data.purl)).to.equal('http://www.test.com/page.html');
-
-      expect(data.s).to.be.an('array');
-      expect(data.s.length).to.equal(1);
-      expect(data.s[0].ps[0].pn).to.equal('appnexus');
-      expect(data.s[0].ps[0].bc).to.equal('appnexus');
+      expect(data.rd.pubid).to.equal('9999');
+      expect(decodeURIComponent(data.rd.purl)).to.equal('http://www.test.com/page.html');
     })
   });
 
-  describe('when handling events', function() {
+  describe('when handling events', function () {
     beforeEach(function () {
       pubmaticAnalyticsAdapter.enableAnalytics({
         options: {
@@ -535,7 +540,8 @@ describe('pubmatic analytics adapter', function () {
       pubmaticAnalyticsAdapter.disableAnalytics();
     });
 
-    it('Logger: best case + win tracker', function() {
+   
+    it('Logger: best case + win tracker', function () {
       this.timeout(5000)
 
       sandbox.stub($$PREBID_GLOBAL$$, 'getHighestCpmBids').callsFake((key) => {
@@ -559,122 +565,55 @@ describe('pubmatic analytics adapter', function () {
       clock.tick(2000 + 1000);
       expect(requests.length).to.equal(3); // 1 logger and 2 win-tracker
       let request = requests[2]; // logger is executed late, trackers execute first
-      expect(request.url).to.equal('https://t.pubmatic.com/wl?pubid=9999');
+      expect(request.url).to.equal('https://t.pubmatic.com/wl?v=1&psrc=web');
       let data = getLoggerJsonFromRequest(request.requestBody);
-      expect(data.pubid).to.equal('9999');
-      expect(data.pid).to.equal('1111');
-      expect(data.pdvid).to.equal('20');
-      expect(data.iid).to.equal('25c6d7f5-699a-4bfc-87c9-996f915341fa');
-      expect(data.to).to.equal('3000');
-      expect(data.purl).to.equal('http://www.test.com/page.html');
-      expect(data.orig).to.equal('www.test.com');
-      expect(data.tst).to.equal(1519767016);
-      expect(data.tgid).to.equal(15);
-      expect(data.fmv).to.equal('floorModelTest');
-      expect(data.ft).to.equal(1);
-      expect(data.pbv).to.equal('$prebid.version$' || '-1');
-      expect(data.s).to.be.an('array');
-      expect(data.s.length).to.equal(2);
-      expect(data.ffs).to.equal(1);
-      expect(data.fsrc).to.equal(2);
-      expect(data.fp).to.equal('pubmatic');
-      // slot 1
-      expect(data.s[0].sn).to.equal('/19968336/header-bid-tag-0');
-      expect(data.s[0].fskp).to.equal(0);
-      expect(data.s[0].sid).not.to.be.undefined;
-      expect(data.s[0].sz).to.deep.equal(['640x480']);
-      expect(data.s[0].ps).to.be.an('array');
-      expect(data.s[0].au).to.equal('/19968336/header-bid-tag-0');
-      expect(data.s[0].ps.length).to.equal(1);
-      expect(data.s[0].ps[0].pn).to.equal('pubmatic');
-      expect(data.s[0].ps[0].bc).to.equal('pubmatic');
-      expect(data.s[0].ps[0].bidid).to.equal('2ecff0db240757');
-      expect(data.s[0].ps[0].origbidid).to.equal('partnerImpressionID-1');
-      expect(data.s[0].ps[0].db).to.equal(0);
-      expect(data.s[0].ps[0].kgpv).to.equal('/19968336/header-bid-tag-0');
-      expect(data.s[0].ps[0].kgpsv).to.equal('/19968336/header-bid-tag-0');
-      expect(data.s[0].ps[0].psz).to.equal('640x480');
-      expect(data.s[0].ps[0].eg).to.equal(1.23);
-      expect(data.s[0].ps[0].en).to.equal(1.23);
-      expect(data.s[0].ps[0].di).to.equal('-1');
-      expect(data.s[0].ps[0].dc).to.equal('');
-      expect(data.s[0].ps[0].l1).to.equal(944);
-      expect(data.s[0].ps[0].ol1).to.equal(3214);
-      expect(data.s[0].ps[0].l2).to.equal(0);
-      expect(data.s[0].ps[0].ss).to.equal(1);
-      expect(data.s[0].ps[0].t).to.equal(0);
-      expect(data.s[0].ps[0].wb).to.equal(1);
-      expect(data.s[0].ps[0].af).to.equal('video');
-      expect(data.s[0].ps[0].ocpm).to.equal(1.23);
-      expect(data.s[0].ps[0].ocry).to.equal('USD');
-      expect(data.s[0].ps[0].frv).to.equal(1.1);
-      expect(data.s[0].ps[0].pb).to.equal(1.2);
-      // slot 2
-      expect(data.s[1].sn).to.equal('/19968336/header-bid-tag-1');
-      expect(data.s[1].fskp).to.equal(0);
-      expect(data.s[1].sid).not.to.be.undefined;
-      expect(data.s[1].sz).to.deep.equal(['1000x300', '970x250', '728x90']);
-      expect(data.s[1].ps).to.be.an('array');
-      expect(data.s[1].ps.length).to.equal(1);
-      expect(data.s[1].ps[0].pn).to.equal('pubmatic');
-      expect(data.s[0].ps[0].bc).to.equal('pubmatic');
-      expect(data.s[1].ps[0].bidid).to.equal('3bd4ebb1c900e2');
-      expect(data.s[1].ps[0].origbidid).to.equal('partnerImpressionID-2');
-      expect(data.s[1].ps[0].db).to.equal(0);
-      expect(data.s[1].ps[0].kgpv).to.equal('this-is-a-kgpv');
-      expect(data.s[1].ps[0].kgpsv).to.equal('this-is-a-kgpv');
-      expect(data.s[1].ps[0].psz).to.equal('728x90');
-      expect(data.s[1].ps[0].eg).to.equal(1.52);
-      expect(data.s[1].ps[0].en).to.equal(1.52);
-      expect(data.s[1].ps[0].di).to.equal('the-deal-id');
-      expect(data.s[1].ps[0].dc).to.equal('PMP');
-      expect(data.s[1].ps[0].mi).to.equal('matched-impression');
-      expect(data.s[1].ps[0].adv).to.equal('example.com');
-      expect(data.s[0].ps[0].l1).to.equal(944);
-      expect(data.s[0].ps[0].ol1).to.equal(3214);
-      expect(data.s[1].ps[0].l2).to.equal(0);
-      expect(data.s[1].ps[0].ss).to.equal(1);
-      expect(data.s[1].ps[0].t).to.equal(0);
-      expect(data.s[1].ps[0].wb).to.equal(1);
-      expect(data.s[1].ps[0].af).to.equal('banner');
-      expect(data.s[1].ps[0].ocpm).to.equal(1.52);
-      expect(data.s[1].ps[0].ocry).to.equal('USD');
-      expect(data.s[1].ps[0].frv).to.equal(1.1);
-      expect(data.s[1].ps[0].pb).to.equal(1.50);
+      // check mandatory fields
+      expect(data).to.have.property('sd');
+      expect(data).to.have.property('fd');
+      expect(data).to.have.property('rd');
+
+      expect(data.rd.pubid).to.equal('9999');
+      expect(data.rd.pid).to.equal('1111');
+      expect(data.rd.pdvid).to.equal('20');
+      expect(data.rd.iid).to.equal('25c6d7f5-699a-4bfc-87c9-996f915341fa');
+      expect(data.rd.to).to.equal(3000);
+      expect(data.rd.purl).to.equal('http://www.test.com/page.html');
+      expect(data.rd.tst).to.equal(1519767016);
+      expect(data.rd.tgid).to.equal(15);
+
+      expect(data.rd.pbv).to.equal('$prebid.version$' || '-1');
+      // floor data in featureList
+      expect(data.fd.flr.modelVersion).to.equal('floorModelTest');
+      expect(data.fd.flr).to.have.property('enforcements');
+      expect(data.fd.flr.enforcements).to.deep.equal({
+        enforceJS: true,
+        enforcePBS: false,
+        floorDeals: false,
+        bidAdjustment: true
+      });
+      expect(data.fd.flr.fetchStatus).to.equal('success');
+      expect(data.fd.flr.floorProvider).to.equal('pubmatic');
+      expect(data.fd.flr.location).to.equal('fetch');
+      expect(data.fd.flr.skipRate).to.equal(0);
+      expect(data.fd.flr.skipped).to.equal(false);;
+
+      expect(data.sd).to.be.an('object');
+      expect(Object.keys(data.sd).length).to.equal(2);
 
       // tracker slot1
       let firstTracker = requests[0].url;
       expect(firstTracker.split('?')[0]).to.equal('https://t.pubmatic.com/wt');
       data = {};
       firstTracker.split('?')[1].split('&').map(e => e.split('=')).forEach(e => data[e[0]] = e[1]);
-      expect(data.pubid).to.equal('9999');
-      expect(decodeURIComponent(data.purl)).to.equal('http://www.test.com/page.html');
-      expect(data.tst).to.equal('1519767014');
-      expect(data.iid).to.equal('25c6d7f5-699a-4bfc-87c9-996f915341fa');
-      expect(data.bidid).to.equal('2ecff0db240757');
-      expect(data.pid).to.equal('1111');
-      expect(data.pdvid).to.equal('20');
-      expect(decodeURIComponent(data.slot)).to.equal('/19968336/header-bid-tag-0');
-      expect(decodeURIComponent(data.kgpv)).to.equal('/19968336/header-bid-tag-0');
-      expect(data.pn).to.equal('pubmatic');
-      expect(data.bc).to.equal('pubmatic');
-      expect(data.eg).to.equal('1.23');
-      expect(data.en).to.equal('1.23');
-      expect(data.origbidid).to.equal('partnerImpressionID-1');
-      expect(data.plt).to.equal('1');
-      expect(data.psz).to.equal('640x480');
-      expect(data.tgid).to.equal('15');
-      expect(data.orig).to.equal('www.test.com');
-      expect(data.ss).to.equal('1');
-      expect(data.fskp).to.equal('0');
-      expect(data.af).to.equal('video');
-      expect(data.ffs).to.equal('1');
-      expect(data.ds).to.equal('1208');
+
+      expect(data.v).to.equal('1');
+      expect(data.psrc).to.equal('web');
     });
 
-    it('Logger : do not log floor fields when prebids floor shows noData in location property', function() {
+   
+    it('Logger: log floor fields when prebids floor shows setConfig in location property', function () {
       const BID_REQUESTED_COPY = utils.deepClone(MOCK.BID_REQUESTED);
-      BID_REQUESTED_COPY['bids'][1]['floorData']['location'] = 'noData';
+      BID_REQUESTED_COPY['bids'][1]['floorData']['location'] = 'fetch';
 
       this.timeout(5000)
 
@@ -699,68 +638,33 @@ describe('pubmatic analytics adapter', function () {
       clock.tick(2000 + 1000);
       expect(requests.length).to.equal(3); // 1 logger and 2 win-tracker
       let request = requests[2]; // logger is executed late, trackers execute first
-      expect(request.url).to.equal('https://t.pubmatic.com/wl?pubid=9999');
+      expect(request.url).to.equal('https://t.pubmatic.com/wl?v=1&psrc=web');
 
       let data = getLoggerJsonFromRequest(request.requestBody);
+      // check mandatory fields
+      expect(data).to.have.property('sd');
+      expect(data).to.have.property('fd');
+      expect(data).to.have.property('rd');
 
-      expect(data.pubid).to.equal('9999');
-      expect(data.fmv).to.equal(undefined);
-
-      // slot 1
-      expect(data.s[0].sn).to.equal('/19968336/header-bid-tag-0');
-      expect(data.s[0].au).to.equal('/19968336/header-bid-tag-0');
-
-      // slot 2
-      expect(data.s[1].sn).to.equal('/19968336/header-bid-tag-1');
-      expect(data.s[1].au).to.equal('/19968336/header-bid-tag-1');
-      expect(data.s[1].fskp).to.equal(undefined);
+      expect(data.rd.pubid).to.equal('9999');
+      // floor data in featureList
+      expect(data.fd.flr.modelVersion).to.equal('floorModelTest');
+      expect(data.fd.flr).to.have.property('enforcements');
+      expect(data.fd.flr.enforcements).to.deep.equal({
+        enforceJS: true,
+        enforcePBS: false,
+        floorDeals: false,
+        bidAdjustment: true
+      });
+      expect(data.fd.flr.fetchStatus).to.equal('success');
+      expect(data.fd.flr.floorProvider).to.equal('pubmatic');
+      expect(data.fd.flr.location).to.equal('fetch');
+      expect(data.fd.flr.skipRate).to.equal(0);
+      expect(data.fd.flr.skipped).to.equal(false);;
     });
 
-    it('Logger: log floor fields when prebids floor shows setConfig in location property', function() {
-      const BID_REQUESTED_COPY = utils.deepClone(MOCK.BID_REQUESTED);
-      BID_REQUESTED_COPY['bids'][1]['floorData']['location'] = 'setConfig';
-
-      this.timeout(5000)
-
-      sandbox.stub($$PREBID_GLOBAL$$, 'getHighestCpmBids').callsFake((key) => {
-        return [MOCK.BID_RESPONSE[0], MOCK.BID_RESPONSE[1]]
-      });
-
-      config.setConfig({
-        testGroupId: 15
-      });
-
-      events.emit(AUCTION_INIT, MOCK.AUCTION_INIT);
-      events.emit(BID_REQUESTED, BID_REQUESTED_COPY);
-      events.emit(BID_RESPONSE, MOCK.BID_RESPONSE[0]);
-      events.emit(BID_RESPONSE, MOCK.BID_RESPONSE[1]);
-      events.emit(BIDDER_DONE, MOCK.BIDDER_DONE);
-      events.emit(AUCTION_END, MOCK.AUCTION_END);
-      events.emit(SET_TARGETING, MOCK.SET_TARGETING);
-      events.emit(BID_WON, MOCK.BID_WON[0]);
-      events.emit(BID_WON, MOCK.BID_WON[1]);
-
-      clock.tick(2000 + 1000);
-      expect(requests.length).to.equal(3); // 1 logger and 2 win-tracker
-      let request = requests[2]; // logger is executed late, trackers execute first
-      expect(request.url).to.equal('https://t.pubmatic.com/wl?pubid=9999');
-
-      let data = getLoggerJsonFromRequest(request.requestBody);
-
-      expect(data.pubid).to.equal('9999');
-      expect(data.fmv).to.equal('floorModelTest');
-
-      // slot 1
-      expect(data.s[0].sn).to.equal('/19968336/header-bid-tag-0');
-      expect(data.s[0].au).to.equal('/19968336/header-bid-tag-0');
-
-      // slot 2
-      expect(data.s[1].sn).to.equal('/19968336/header-bid-tag-1');
-      expect(data.s[1].au).to.equal('/19968336/header-bid-tag-1');
-      expect(data.s[1].fskp).to.equal(0);
-    });
-
-    it('bidCpmAdjustment: USD: Logger: best case + win tracker', function() {
+    // done
+    it('bidCpmAdjustment: USD: Logger: best case + win tracker', function () {
       const bidCopy = utils.deepClone(BID);
       bidCopy.cpm = bidCopy.originalCpm * 2; //  bidCpmAdjustment => bidCpm * 2
       this.timeout(5000)
@@ -780,55 +684,52 @@ describe('pubmatic analytics adapter', function () {
       events.emit(BID_WON, MOCK.BID_WON[0]);
       events.emit(BID_WON, MOCK.BID_WON[1]);
 
-      clock.tick(2000 + 1000);
+      clock.tick(3000 + 2000);
       expect(requests.length).to.equal(3); // 1 logger and 2 win-tracker
       let request = requests[2]; // logger is executed late, trackers execute first
-      expect(request.url).to.equal('https://t.pubmatic.com/wl?pubid=9999');
+      expect(request.url).to.equal('https://t.pubmatic.com/wl?v=1&psrc=web');
       let data = getLoggerJsonFromRequest(request.requestBody);
-      expect(data.pubid).to.equal('9999');
-      expect(data.pid).to.equal('1111');
-      expect(data.fmv).to.equal('floorModelTest');
-      expect(data.ft).to.equal(1);
-      expect(data.pbv).to.equal('$prebid.version$' || '-1');
-      expect(data.s).to.be.an('array');
-      expect(data.s.length).to.equal(2);
-      expect(data.ffs).to.equal(1);
-      expect(data.fsrc).to.equal(2);
-      expect(data.fp).to.equal('pubmatic');
-      expect(data.tgid).to.equal(0);
-      // slot 1
-      expect(data.s[0].sn).to.equal('/19968336/header-bid-tag-0');
-      expect(data.s[0].fskp).to.equal(0);
-      expect(data.s[0].sid).not.to.be.undefined;
-      expect(data.s[0].sz).to.deep.equal(['640x480']);
-      expect(data.s[0].ps).to.be.an('array');
-      expect(data.s[0].au).to.equal('/19968336/header-bid-tag-0');
-      expect(data.s[0].ps.length).to.equal(1);
-      expect(data.s[0].ps[0].pn).to.equal('pubmatic');
-      expect(data.s[0].ps[0].bc).to.equal('pubmatic');
-      expect(data.s[0].ps[0].bidid).to.equal('2ecff0db240757');
-      expect(data.s[0].ps[0].kgpv).to.equal('/19968336/header-bid-tag-0');
-      expect(data.s[0].ps[0].eg).to.equal(1.23);
-      expect(data.s[0].ps[0].en).to.equal(2.46);
-      expect(data.s[0].ps[0].wb).to.equal(1);
-      expect(data.s[0].ps[0].af).to.equal('video');
-      expect(data.s[0].ps[0].ocpm).to.equal(1.23);
-      expect(data.s[0].ps[0].ocry).to.equal('USD');
-      expect(data.s[1].ps[0].frv).to.equal(1.1);
-      expect(data.s[1].ps[0].pb).to.equal(1.50);
+
+      // check mandatory fields
+      expect(data).to.have.property('sd');
+      expect(data).to.have.property('fd');
+      expect(data).to.have.property('rd');
+
+      expect(data.rd.pubid).to.equal('9999');
+      expect(data.rd.pid).to.equal('1111');
+      expect(data.rd.tgid).to.equal(0);
+      // floor data in featureList
+      expect(data.fd.flr.modelVersion).to.equal('floorModelTest');
+      expect(data.fd.flr).to.have.property('enforcements');
+      expect(data.fd.flr.enforcements).to.deep.equal({
+        enforceJS: true,
+        enforcePBS: false,
+        floorDeals: false,
+        bidAdjustment: true
+      });
+      expect(data.fd.flr.fetchStatus).to.equal('success');
+      expect(data.fd.flr.floorProvider).to.equal('pubmatic');
+      expect(data.fd.flr.location).to.equal('fetch');
+      expect(data.fd.flr.skipRate).to.equal(0);
+      expect(data.fd.flr.skipped).to.equal(false);
+
+      expect(data.rd.pbv).to.equal('$prebid.version$' || '-1');
+      expect(data.sd).to.be.an('object');
+      expect(Object.keys(data.sd).length).to.equal(2);
+
+      expect(data.sd['/19968336/header-bid-tag-0'].bids['2ecff0db240757'][0].bidResponse.bidGrossCpmUSD).to.equal(1.23);
+      expect(data.sd['/19968336/header-bid-tag-0'].bids['2ecff0db240757'][0].bidResponse.bidPriceUSD).to.equal(2.46);
       // tracker slot1
       let firstTracker = requests[0].url;
       expect(firstTracker.split('?')[0]).to.equal('https://t.pubmatic.com/wt');
       data = {};
       firstTracker.split('?')[1].split('&').map(e => e.split('=')).forEach(e => data[e[0]] = e[1]);
-      expect(data.pubid).to.equal('9999');
-      expect(data.tst).to.equal('1519767014');
-      expect(data.iid).to.equal('25c6d7f5-699a-4bfc-87c9-996f915341fa');
-      expect(data.eg).to.equal('1.23');
-      expect(data.en).to.equal('2.46');
+      expect(data.v).to.equal('1');
+      expect(data.psrc).to.equal('web');
     });
 
-    it('bidCpmAdjustment: JPY: Logger: best case + win tracker', function() {
+   
+    it('bidCpmAdjustment: JPY: Logger: best case + win tracker', function () {
       config.setConfig({
         testGroupId: 25
       });
@@ -849,7 +750,6 @@ describe('pubmatic analytics adapter', function () {
 
       events.emit(AUCTION_INIT, MOCK.AUCTION_INIT);
       events.emit(BID_REQUESTED, MOCK.BID_REQUESTED);
-      // events.emit(BID_RESPONSE, MOCK.BID_RESPONSE[0]);
       events.emit(BID_RESPONSE, bidCopy);
       events.emit(BID_RESPONSE, MOCK.BID_RESPONSE[1]);
       events.emit(BID_RESPONSE, bidCopy);
@@ -862,45 +762,47 @@ describe('pubmatic analytics adapter', function () {
       clock.tick(2000 + 1000);
       expect(requests.length).to.equal(3); // 1 logger and 2 win-tracker
       let request = requests[2]; // logger is executed late, trackers execute first
-      expect(request.url).to.equal('https://t.pubmatic.com/wl?pubid=9999');
+      expect(request.url).to.equal('https://t.pubmatic.com/wl?v=1&psrc=web');
       let data = getLoggerJsonFromRequest(request.requestBody);
-      expect(data.pubid).to.equal('9999');
-      expect(data.pid).to.equal('1111');
-      expect(data.tgid).to.equal(0);// test group id should be between 0-15 else set to 0
-      expect(data.fmv).to.equal('floorModelTest');
-      expect(data.ft).to.equal(1);
-      expect(data.pbv).to.equal('$prebid.version$' || '-1');
-      expect(data.s).to.be.an('array');
-      expect(data.s.length).to.equal(2);
-      // slot 1
-      expect(data.s[0].sn).to.equal('/19968336/header-bid-tag-0');
-      expect(data.s[0].sz).to.deep.equal(['640x480']);
-      expect(data.s[0].ps).to.be.an('array');
-      expect(data.s[0].ps.length).to.equal(1);
-      expect(data.s[0].au).to.equal('/19968336/header-bid-tag-0');
-      expect(data.s[0].ps[0].pn).to.equal('pubmatic');
-      expect(data.s[0].ps[0].bc).to.equal('pubmatic');
-      expect(data.s[0].ps[0].bidid).to.equal('2ecff0db240757');
-      expect(data.s[0].ps[0].kgpv).to.equal('/19968336/header-bid-tag-0');
-      expect(data.s[0].ps[0].eg).to.equal(1);
-      expect(data.s[0].ps[0].en).to.equal(200);
-      expect(data.s[0].ps[0].wb).to.equal(0); // bidPriceUSD is not getting set as currency module is not added, so unable to set wb to 1
-      expect(data.s[0].ps[0].af).to.equal('video');
-      expect(data.s[0].ps[0].ocpm).to.equal(100);
-      expect(data.s[0].ps[0].ocry).to.equal('JPY');
+      // check mandatory fields
+      expect(data).to.have.property('sd');
+      expect(data).to.have.property('fd');
+      expect(data).to.have.property('rd');
+
+      expect(data.rd.pubid).to.equal('9999');
+      expect(data.rd.pid).to.equal('1111');
+      expect(data.rd.tgid).to.equal(0);// test group id should be between 0-15 else set to 0
+      // floor data in featureList
+      expect(data.fd.flr.modelVersion).to.equal('floorModelTest');
+      expect(data.fd.flr).to.have.property('enforcements');
+      expect(data.fd.flr.enforcements).to.deep.equal({
+        enforceJS: true,
+        enforcePBS: false,
+        floorDeals: false,
+        bidAdjustment: true
+      });
+      expect(data.fd.flr.fetchStatus).to.equal('success');
+      expect(data.fd.flr.floorProvider).to.equal('pubmatic');
+      expect(data.fd.flr.location).to.equal('fetch');
+      expect(data.fd.flr.skipRate).to.equal(0);
+      expect(data.fd.flr.skipped).to.equal(false);;
+      expect(data.rd.pbv).to.equal('$prebid.version$' || '-1');
+      expect(data.sd).to.be.an('object');
+      expect(Object.keys(data.sd).length).to.equal(2);
+      expect(data.sd['/19968336/header-bid-tag-0'].bids['2ecff0db240757'][0].bidResponse.bidGrossCpmUSD).to.equal(1);
+      expect(data.sd['/19968336/header-bid-tag-0'].bids['2ecff0db240757'][0].bidResponse.bidPriceUSD).to.equal(200); // bidPriceUSD is not getting set as currency module is not added
+
       // tracker slot1
       let firstTracker = requests[0].url;
       expect(firstTracker.split('?')[0]).to.equal('https://t.pubmatic.com/wt');
       data = {};
       firstTracker.split('?')[1].split('&').map(e => e.split('=')).forEach(e => data[e[0]] = e[1]);
-      expect(data.pubid).to.equal('9999');
-      expect(data.tst).to.equal('1519767014');
-      expect(data.iid).to.equal('25c6d7f5-699a-4bfc-87c9-996f915341fa');
-      expect(data.eg).to.equal('1');
-      expect(data.en).to.equal('200'); // bidPriceUSD is not getting set as currency module is not added
+      expect(data.v).to.equal('1');
+      expect(data.psrc).to.equal('web');
     });
 
-    it('Logger: when bid is not submitted, default bid status 1 check: pubmatic set as s2s', function() {
+    
+    it('Logger: when bid is not submitted, default bid status 1 check: pubmatic set as s2s', function () {
       config.setConfig({
         testGroupId: '25'
       });
@@ -917,41 +819,27 @@ describe('pubmatic analytics adapter', function () {
       expect(requests.length).to.equal(2); // 1 logger and 1 win-tracker
       let request = requests[1]; // logger is executed late, trackers execute first
       let data = getLoggerJsonFromRequest(request.requestBody);
-      expect(data.tgid).to.equal(0);// test group id should be an INT between 0-15 else set to 0
-      expect(data.ffs).to.equal(1);
-      expect(data.fsrc).to.equal(2);
-      expect(data.fp).to.equal('pubmatic');
 
-      expect(data.s[1].sn).to.equal('/19968336/header-bid-tag-1');
-      expect(data.s[1].fskp).to.equal(0);
-      expect(data.s[1].sid).not.to.be.undefined;
-      expect(data.s[1].sz).to.deep.equal(['1000x300', '970x250', '728x90']);
-      expect(data.s[1].ps).to.be.an('array');
-      expect(data.s[1].ps.length).to.equal(1);
-      expect(data.s[1].ps[0].pn).to.equal('pubmatic');
-      expect(data.s[0].ps[0].bc).to.equal('pubmatic');
-      expect(data.s[1].ps[0].bidid).to.equal('3bd4ebb1c900e2');
-      expect(data.s[1].ps[0].db).to.equal(1);
-      expect(data.s[1].ps[0].kgpv).to.equal('this-is-a-kgpv');
-      expect(data.s[1].ps[0].kgpsv).to.equal('this-is-a-kgpv');
-      expect(data.s[1].ps[0].psz).to.equal('0x0');
-      expect(data.s[1].ps[0].eg).to.equal(0);
-      expect(data.s[1].ps[0].en).to.equal(0);
-      expect(data.s[1].ps[0].di).to.equal('-1');
-      expect(data.s[1].ps[0].dc).to.equal('');
-      expect(data.s[1].ps[0].mi).to.equal(undefined);
-      expect(data.s[1].ps[0].l1).to.equal(0);
-      expect(data.s[1].ps[0].l2).to.equal(0);
-      expect(data.s[1].ps[0].ss).to.equal(1);
-      expect(data.s[1].ps[0].t).to.equal(0);
-      expect(data.s[1].ps[0].wb).to.equal(0);
-      expect(data.s[1].ps[0].af).to.equal(undefined);
-      expect(data.s[1].ps[0].ocpm).to.equal(0);
-      expect(data.s[1].ps[0].ocry).to.equal('USD');
-      expect(data.s[1].ps[0].frv).to.equal(undefined);
+      // check mandatory fields
+      expect(data).to.have.property('sd');
+      expect(data).to.have.property('fd');
+      expect(data).to.have.property('rd');
+
+      expect(data.rd.tgid).to.equal(0);// test group id should be an INT between 0-15 else set to 0
+
+      expect(data.sd).to.be.an('object');
+      expect(Object.keys(data.sd).length).to.equal(2);
+
+      expect(data.sd).to.have.property('/19968336/header-bid-tag-0');
+      expect(data.sd['/19968336/header-bid-tag-0'].dimensions).to.deep.equal([[640, 480]])
+      expect(data.sd['/19968336/header-bid-tag-0'].bids['2ecff0db240757'][0].adapterCode).to.equal('pubmatic');
+      expect(data.sd['/19968336/header-bid-tag-0'].bids['2ecff0db240757'][0].bidderCode).to.equal('pubmatic');
+      expect(data.sd['/19968336/header-bid-tag-0'].bids['2ecff0db240757'][0].bidResponse.originalCpm).to.equal(1.23);
+      expect(data.sd['/19968336/header-bid-tag-0'].bids['2ecff0db240757'][0].bidResponse.originalCurrency).to.equal('USD');
     });
 
-    it('Logger: post-timeout check without bid response', function() {
+    
+    it('Logger: post-timeout check without bid response', function () {
       // db = 1 and t = 1 means bidder did NOT respond with a bid but we got a timeout notification
       events.emit(AUCTION_INIT, MOCK.AUCTION_INIT);
       events.emit(BID_REQUESTED, MOCK.BID_REQUESTED);
@@ -962,33 +850,23 @@ describe('pubmatic analytics adapter', function () {
       expect(requests.length).to.equal(1); // 1 logger and 0 win-tracker
       let request = requests[0];
       let data = getLoggerJsonFromRequest(request.requestBody);
-      expect(data.s[1].sn).to.equal('/19968336/header-bid-tag-1');
-      expect(data.s[1].sz).to.deep.equal(['1000x300', '970x250', '728x90']);
-      expect(data.s[1].ps).to.be.an('array');
-      expect(data.s[1].ps.length).to.equal(1);
-      expect(data.s[1].ps[0].pn).to.equal('pubmatic');
-      expect(data.s[0].ps[0].bc).to.equal('pubmatic');
-      expect(data.s[1].ps[0].bidid).to.equal('3bd4ebb1c900e2');
-      expect(data.s[1].ps[0].db).to.equal(1);
-      expect(data.s[1].ps[0].kgpv).to.equal('this-is-a-kgpv');
-      expect(data.s[1].ps[0].kgpsv).to.equal('this-is-a-kgpv');
-      expect(data.s[1].ps[0].psz).to.equal('0x0');
-      expect(data.s[1].ps[0].eg).to.equal(0);
-      expect(data.s[1].ps[0].en).to.equal(0);
-      expect(data.s[1].ps[0].di).to.equal('-1');
-      expect(data.s[1].ps[0].dc).to.equal('');
-      expect(data.s[1].ps[0].mi).to.equal(undefined);
-      expect(data.s[1].ps[0].l1).to.equal(0);
-      expect(data.s[1].ps[0].l2).to.equal(0);
-      expect(data.s[1].ps[0].ss).to.equal(1);
-      expect(data.s[1].ps[0].t).to.equal(1);
-      expect(data.s[1].ps[0].wb).to.equal(0);
-      expect(data.s[1].ps[0].af).to.equal(undefined);
-      expect(data.s[1].ps[0].ocpm).to.equal(0);
-      expect(data.s[1].ps[0].ocry).to.equal('USD');
+      // check mandatory fields
+      expect(data).to.have.property('sd');
+      expect(data).to.have.property('fd');
+      expect(data).to.have.property('rd');
+
+      expect(data.sd).to.be.an('object');
+      expect(Object.keys(data.sd).length).to.equal(2);
+      expect(data.sd).to.have.property('/19968336/header-bid-tag-1');
+      expect(data.sd['/19968336/header-bid-tag-1'].dimensions).to.deep.equal([[1000, 300], [970, 250], [728, 90]]);
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].adapterCode).to.equal('pubmatic');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidderCode).to.equal('pubmatic');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].params.kgpv).to.equal('this-is-a-kgpv');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0]).to.not.have.property('bidResponse')
     });
 
-    it('Logger: post-timeout check with bid response', function() {
+    
+    it('Logger: post-timeout check with bid response', function () {
       // db = 1 and t = 1 means bidder did NOT respond with a bid but we got a timeout notification
 
       sandbox.stub($$PREBID_GLOBAL$$, 'getHighestCpmBids').callsFake((key) => {
@@ -1005,43 +883,33 @@ describe('pubmatic analytics adapter', function () {
       expect(requests.length).to.equal(1); // 1 logger and 0 win-tracker
       let request = requests[0];
       let data = getLoggerJsonFromRequest(request.requestBody);
-      expect(data.ffs).to.equal(1);
-      expect(data.fsrc).to.equal(2);
-      expect(data.fp).to.equal('pubmatic');
+      // check mandatory fields
+      expect(data).to.have.property('sd');
+      expect(data).to.have.property('fd');
+      expect(data).to.have.property('rd');
 
-      expect(data.s[1].sn).to.equal('/19968336/header-bid-tag-1');
-      expect(data.s[1].fskp).to.equal(0);
-      expect(data.s[1].sid).not.to.be.undefined;
-      expect(data.s[1].sz).to.deep.equal(['1000x300', '970x250', '728x90']);
-      expect(data.s[1].ps).to.be.an('array');
-      expect(data.s[1].ps.length).to.equal(1);
-      expect(data.s[1].ps[0].pn).to.equal('pubmatic');
-      expect(data.s[1].ps[0].bc).to.equal('pubmatic');
-      expect(data.s[1].ps[0].bidid).to.equal('3bd4ebb1c900e2');
-      expect(data.s[1].ps[0].db).to.equal(0);
-      expect(data.s[1].ps[0].kgpv).to.equal('this-is-a-kgpv');
-      expect(data.s[1].ps[0].kgpsv).to.equal('this-is-a-kgpv');
-      expect(data.s[1].ps[0].psz).to.equal('728x90');
-      expect(data.s[1].ps[0].eg).to.equal(1.52);
-      expect(data.s[1].ps[0].en).to.equal(1.52);
-      expect(data.s[1].ps[0].di).to.equal('the-deal-id');
-      expect(data.s[1].ps[0].dc).to.equal('PMP');
-      expect(data.s[1].ps[0].mi).to.equal('matched-impression');
-      expect(data.s[1].ps[0].adv).to.equal('example.com');
-      expect(data.s[0].ps[0].l1).to.equal(0);
-      expect(data.s[0].ps[0].ol1).to.equal(0);
-      expect(data.s[1].ps[0].l2).to.equal(0);
-      expect(data.s[1].ps[0].ss).to.equal(1);
-      expect(data.s[1].ps[0].t).to.equal(1);
-      expect(data.s[1].ps[0].wb).to.equal(1); // todo
-      expect(data.s[1].ps[0].af).to.equal('banner');
-      expect(data.s[1].ps[0].ocpm).to.equal(1.52);
-      expect(data.s[1].ps[0].ocry).to.equal('USD');
-      expect(data.s[1].ps[0].frv).to.equal(1.1);
-      expect(data.s[1].ps[0].pb).to.equal(1.50);
+      expect(data.sd).to.have.property('/19968336/header-bid-tag-1');
+      expect(data.sd['/19968336/header-bid-tag-1'].dimensions).to.deep.equal([[1000, 300], [970, 250], [728, 90]]);
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].adapterCode).to.equal('pubmatic');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidderCode).to.equal('pubmatic');
+
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].params.kgpv).to.equal('this-is-a-kgpv');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0]).to.have.property('bidResponse');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.originalCpm).to.equal(1.52);
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.originalCurrency).to.equal('USD');
+
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.dealId).to.equal('the-deal-id');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].partnerTimeToRespond).to.equal(944);
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].clientLatencyTimeMs).to.equal(3214);
+      expect(data.rd.s2sls).to.deep.equal(['pubmatic']);
+
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].status).to.equal('error');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.mediaType).to.equal('banner');
+
     });
 
-    it('Logger: currency conversion check', function() {
+    
+    it('Logger: currency conversion check', function () {
       setUANull();
       setConfig({
         adServerCurrency: 'JPY',
@@ -1070,39 +938,27 @@ describe('pubmatic analytics adapter', function () {
       clock.tick(2000 + 1000);
       expect(requests.length).to.equal(3); // 1 logger and 2 win-tracker
       let request = requests[2]; // logger is executed late, trackers execute first
-      expect(request.url).to.equal('https://t.pubmatic.com/wl?pubid=9999');
+      expect(request.url).to.equal('https://t.pubmatic.com/wl?v=1&psrc=web');
       let data = getLoggerJsonFromRequest(request.requestBody);
-      expect(data.s[1].sn).to.equal('/19968336/header-bid-tag-1');
-      expect(data.s[1].sz).to.deep.equal(['1000x300', '970x250', '728x90']);
-      expect(data.s[1].ps).to.be.an('array');
-      expect(data.s[1].sid).not.to.be.undefined;
-      expect(data.s[1].ps.length).to.equal(1);
-      expect(data.s[1].ps[0].pn).to.equal('pubmatic');
-      expect(data.s[1].ps[0].bc).to.equal('pubmatic');
-      expect(data.s[1].ps[0].bidid).to.equal('3bd4ebb1c900e2');
-      expect(data.s[1].ps[0].db).to.equal(0);
-      expect(data.s[1].ps[0].kgpv).to.equal('this-is-a-kgpv');
-      expect(data.s[1].ps[0].kgpsv).to.equal('this-is-a-kgpv');
-      expect(data.s[1].ps[0].psz).to.equal('728x90');
-      expect(data.s[1].ps[0].eg).to.equal(1);
-      expect(data.s[1].ps[0].en).to.equal(100);
-      expect(data.s[1].ps[0].di).to.equal('the-deal-id');
-      expect(data.s[1].ps[0].dc).to.equal('PMP');
-      expect(data.s[1].ps[0].mi).to.equal('matched-impression');
-      expect(data.s[1].ps[0].adv).to.equal('example.com');
-      expect(data.s[0].ps[0].l1).to.equal(944);
-      expect(data.s[0].ps[0].ol1).to.equal(3214);
-      expect(data.s[1].ps[0].l2).to.equal(0);
-      expect(data.s[1].ps[0].ss).to.equal(1);
-      expect(data.s[1].ps[0].t).to.equal(0);
-      expect(data.s[1].ps[0].wb).to.equal(0); // bidPriceUSD is not getting set as currency module is not added, so unable to set wb to 1
-      expect(data.s[1].ps[0].af).to.equal('banner');
-      expect(data.s[1].ps[0].ocpm).to.equal(100);
-      expect(data.s[1].ps[0].ocry).to.equal('JPY');
-      expect(data.dvc).to.deep.equal({'plt': 3});
+      // check mandatory fields
+      expect(data).to.have.property('sd');
+      expect(data).to.have.property('fd');
+      expect(data).to.have.property('rd');
+
+      expect(data.sd).to.have.property('/19968336/header-bid-tag-1');
+      expect(data.sd['/19968336/header-bid-tag-1'].dimensions).to.deep.equal([[1000, 300], [970, 250], [728, 90]]);
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].adapterCode).to.equal('pubmatic');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidderCode).to.equal('pubmatic');
+
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0]).to.have.property('bidResponse');
+
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.originalCpm).to.equal(100);
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.originalCurrency).to.equal('JPY');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.mediaType).to.equal('banner');
+
     });
 
-    it('Logger: regexPattern in bid.params', function() {
+    it('Logger: regexPattern in bid.params', function () {
       setUAMobile();
       const BID_REQUESTED_COPY = utils.deepClone(MOCK.BID_REQUESTED);
       BID_REQUESTED_COPY.bids[1].params.regexPattern = '*';
@@ -1119,51 +975,31 @@ describe('pubmatic analytics adapter', function () {
       clock.tick(2000 + 1000);
       expect(requests.length).to.equal(3); // 1 logger and 2 win-tracker
       let request = requests[2]; // logger is executed late, trackers execute first
-      expect(request.url).to.equal('https://t.pubmatic.com/wl?pubid=9999');
+      expect(request.url).to.equal('https://t.pubmatic.com/wl?v=1&psrc=web');
       let data = getLoggerJsonFromRequest(request.requestBody);
-      expect(data.ffs).to.equal(1);
-      expect(data.fsrc).to.equal(2);
-      expect(data.fp).to.equal('pubmatic');
-      expect(data.s[1].sn).to.equal('/19968336/header-bid-tag-1');
-      expect(data.s[1].fskp).to.equal(0);
-      expect(data.s[1].sid).not.to.be.undefined;
-      expect(data.s[1].sz).to.deep.equal(['1000x300', '970x250', '728x90']);
-      expect(data.s[1].ps).to.be.an('array');
-      expect(data.s[1].ps.length).to.equal(1);
-      expect(data.s[1].ps[0].pn).to.equal('pubmatic');
-      expect(data.s[1].ps[0].bc).to.equal('pubmatic');
-      expect(data.s[1].ps[0].bidid).to.equal('3bd4ebb1c900e2');
-      expect(data.s[1].ps[0].db).to.equal(0);
-      expect(data.s[1].ps[0].kgpv).to.equal('*');
-      expect(data.s[1].ps[0].kgpsv).to.equal('this-is-a-kgpv');
-      expect(data.s[1].ps[0].psz).to.equal('728x90');
-      expect(data.s[1].ps[0].eg).to.equal(1.52);
-      expect(data.s[1].ps[0].en).to.equal(1.52);
-      expect(data.s[1].ps[0].di).to.equal('the-deal-id');
-      expect(data.s[1].ps[0].dc).to.equal('PMP');
-      expect(data.s[1].ps[0].mi).to.equal('matched-impression');
-      expect(data.s[1].ps[0].adv).to.equal('example.com');
-      expect(data.s[0].ps[0].l1).to.equal(944);
-      expect(data.s[0].ps[0].ol1).to.equal(3214);
-      expect(data.s[1].ps[0].l2).to.equal(0);
-      expect(data.s[1].ps[0].ss).to.equal(1);
-      expect(data.s[1].ps[0].t).to.equal(0);
-      expect(data.s[1].ps[0].wb).to.equal(0); // bidPriceUSD is not getting set as currency module is not added, so unable to set wb to 1
-      expect(data.s[1].ps[0].af).to.equal('banner');
-      expect(data.s[1].ps[0].ocpm).to.equal(1.52);
-      expect(data.s[1].ps[0].ocry).to.equal('USD');
-      expect(data.s[1].ps[0].frv).to.equal(1.1);
-      expect(data.s[1].ps[0].pb).to.equal(1.50);
-      expect(data.dvc).to.deep.equal({'plt': 2});
+
+      // check mandatory fields
+      expect(data).to.have.property('sd');
+      expect(data).to.have.property('fd');
+      expect(data).to.have.property('rd');
+
+      expect(data.sd).to.have.property('/19968336/header-bid-tag-1');
+      expect(data.sd['/19968336/header-bid-tag-1'].dimensions).to.deep.equal([[1000, 300], [970, 250], [728, 90]]);
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].adapterCode).to.equal('pubmatic');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidderCode).to.equal('pubmatic');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0]).to.have.property('bidResponse');
+
       // respective tracker slot
       let firstTracker = requests[1].url;
       expect(firstTracker.split('?')[0]).to.equal('https://t.pubmatic.com/wt');
       data = {};
       firstTracker.split('?')[1].split('&').map(e => e.split('=')).forEach(e => data[e[0]] = e[1]);
-      expect(data.kgpv).to.equal('*');
+      expect(data.v).to.equal('1');
+      expect(data.psrc).to.equal('web');
     });
 
-    it('Logger: regexPattern in bid.bidResponse and url in adomain', function() {
+   
+    it('Logger: regexPattern in bid.bidResponse and url in adomain', function () {
       const BID2_COPY = utils.deepClone(BID2);
       BID2_COPY.regexPattern = '*';
       BID2_COPY.meta.advertiserDomains = ['https://www.example.com/abc/223']
@@ -1183,47 +1019,32 @@ describe('pubmatic analytics adapter', function () {
       clock.tick(2000 + 1000);
       expect(requests.length).to.equal(3); // 1 logger and 2 win-tracker
       let request = requests[2]; // logger is executed late, trackers execute first
-      expect(request.url).to.equal('https://t.pubmatic.com/wl?pubid=9999');
+      expect(request.url).to.equal('https://t.pubmatic.com/wl?v=1&psrc=web');
       let data = getLoggerJsonFromRequest(request.requestBody);
-      expect(data.s[1].sn).to.equal('/19968336/header-bid-tag-1');
-      expect(data.s[1].sz).to.deep.equal(['1000x300', '970x250', '728x90']);
-      expect(data.s[1].sid).not.to.be.undefined;
-      expect(data.s[1].ps).to.be.an('array');
-      expect(data.s[1].ps.length).to.equal(1);
-      expect(data.s[1].ps[0].pn).to.equal('pubmatic');
-      expect(data.s[1].ps[0].bc).to.equal('pubmatic');
-      expect(data.s[1].ps[0].bidid).to.equal('3bd4ebb1c900e2');
-      expect(data.s[1].ps[0].db).to.equal(0);
-      expect(data.s[1].ps[0].kgpv).to.equal('*');
-      expect(data.s[1].ps[0].kgpsv).to.equal('this-is-a-kgpv');
-      expect(data.s[1].ps[0].psz).to.equal('728x90');
-      expect(data.s[1].ps[0].eg).to.equal(1.52);
-      expect(data.s[1].ps[0].en).to.equal(1.52);
-      expect(data.s[1].ps[0].di).to.equal('the-deal-id');
-      expect(data.s[1].ps[0].dc).to.equal('PMP');
-      expect(data.s[1].ps[0].mi).to.equal('matched-impression');
-      expect(data.s[1].ps[0].adv).to.equal('example.com');
-      expect(data.s[0].ps[0].l1).to.equal(944);
-      expect(data.s[0].ps[0].ol1).to.equal(3214);
-      expect(data.s[1].ps[0].l2).to.equal(0);
-      expect(data.s[1].ps[0].ss).to.equal(1);
-      expect(data.s[1].ps[0].t).to.equal(0);
-      expect(data.s[1].ps[0].wb).to.equal(0); // bidPriceUSD is not getting set as currency module is not added, so unable to set wb to 1
-      expect(data.s[1].ps[0].af).to.equal('banner');
-      expect(data.s[1].ps[0].ocpm).to.equal(1.52);
-      expect(data.s[1].ps[0].ocry).to.equal('USD');
-      expect(data.dvc).to.deep.equal({'plt': 1});
-      expect(data.s[1].ps[0].frv).to.equal(1.1);
-      expect(data.s[1].ps[0].pb).to.equal(1.50);
+      // check mandatory fields
+      expect(data).to.have.property('sd');
+      expect(data).to.have.property('fd');
+      expect(data).to.have.property('rd');
+
+      expect(data.sd).to.have.property('/19968336/header-bid-tag-1');
+      expect(data.sd['/19968336/header-bid-tag-1'].dimensions).to.deep.equal([[1000, 300], [970, 250], [728, 90]]);
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2']).to.be.an('array');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].adapterCode).to.equal('pubmatic');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidderCode).to.equal('pubmatic');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidderCode).to.equal('pubmatic');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0]).to.have.property('bidResponse');
+     expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.floorData.floorValue).to.equal(1.1);
+
       // respective tracker slot
       let firstTracker = requests[1].url;
       expect(firstTracker.split('?')[0]).to.equal('https://t.pubmatic.com/wt');
       data = {};
       firstTracker.split('?')[1].split('&').map(e => e.split('=')).forEach(e => data[e[0]] = e[1]);
-      expect(data.kgpv).to.equal('*');
+      expect(data.v).to.equal('1');
     });
 
-    it('Logger: regexPattern in bid.params', function() {
+    
+    it('Logger: regexPattern in bid.params', function () {
       const BID_REQUESTED_COPY = utils.deepClone(MOCK.BID_REQUESTED);
       BID_REQUESTED_COPY.bids[1].params.regexPattern = '*';
       events.emit(AUCTION_INIT, MOCK.AUCTION_INIT);
@@ -1239,50 +1060,51 @@ describe('pubmatic analytics adapter', function () {
       clock.tick(2000 + 1000);
       expect(requests.length).to.equal(3); // 1 logger and 2 win-tracker
       let request = requests[2]; // logger is executed late, trackers execute first
-      expect(request.url).to.equal('https://t.pubmatic.com/wl?pubid=9999');
+      expect(request.url).to.equal('https://t.pubmatic.com/wl?v=1&psrc=web');
       let data = getLoggerJsonFromRequest(request.requestBody);
-      expect(data.ffs).to.equal(1);
-      expect(data.fsrc).to.equal(2);
-      expect(data.fp).to.equal('pubmatic');
-      expect(data.s[1].sn).to.equal('/19968336/header-bid-tag-1');
-      expect(data.s[1].fskp).to.equal(0);
-      expect(data.s[1].sid).not.to.be.undefined;
-      expect(data.s[1].sz).to.deep.equal(['1000x300', '970x250', '728x90']);
-      expect(data.s[1].ps).to.be.an('array');
-      expect(data.s[1].ps.length).to.equal(1);
-      expect(data.s[1].ps[0].pn).to.equal('pubmatic');
-      expect(data.s[1].ps[0].bc).to.equal('pubmatic');
-      expect(data.s[1].ps[0].bidid).to.equal('3bd4ebb1c900e2');
-      expect(data.s[1].ps[0].db).to.equal(0);
-      expect(data.s[1].ps[0].kgpv).to.equal('*');
-      expect(data.s[1].ps[0].kgpsv).to.equal('this-is-a-kgpv');
-      expect(data.s[1].ps[0].psz).to.equal('728x90');
-      expect(data.s[1].ps[0].eg).to.equal(1.52);
-      expect(data.s[1].ps[0].en).to.equal(1.52);
-      expect(data.s[1].ps[0].di).to.equal('the-deal-id');
-      expect(data.s[1].ps[0].dc).to.equal('PMP');
-      expect(data.s[1].ps[0].mi).to.equal('matched-impression');
-      expect(data.s[1].ps[0].adv).to.equal('example.com');
-      expect(data.s[0].ps[0].l1).to.equal(944);
-      expect(data.s[0].ps[0].ol1).to.equal(3214);
-      expect(data.s[1].ps[0].l2).to.equal(0);
-      expect(data.s[1].ps[0].ss).to.equal(1);
-      expect(data.s[1].ps[0].t).to.equal(0);
-      expect(data.s[1].ps[0].wb).to.equal(0); // bidPriceUSD is not getting set as currency module is not added, so unable to set wb to 1
-      expect(data.s[1].ps[0].af).to.equal('banner');
-      expect(data.s[1].ps[0].ocpm).to.equal(1.52);
-      expect(data.s[1].ps[0].ocry).to.equal('USD');
-      expect(data.s[1].ps[0].frv).to.equal(1.1);
-      expect(data.s[1].ps[0].pb).to.equal(1.50);
-      // respective tracker slot
+      // check mandatory fields
+      expect(data).to.have.property('sd');
+      expect(data).to.have.property('fd');
+      expect(data).to.have.property('rd');
+
+      expect(data.sd).to.have.property('/19968336/header-bid-tag-1');
+      expect(data.sd['/19968336/header-bid-tag-1'].dimensions).to.deep.equal([[1000, 300], [970, 250], [728, 90]]);
+      expect(data.sd['/19968336/header-bid-tag-1'].bids).to.have.property('3bd4ebb1c900e2');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].adapterCode).to.equal('pubmatic');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidderCode).to.equal('pubmatic');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0]).to.have.property('bidResponse');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidId).to.equal('3bd4ebb1c900e2');
+      expect(data.fd.flr.skipped).to.equal(false);
+
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.bidGrossCpmUSD).to.equal(1.52);
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.bidPriceUSD).to.equal(1.52);
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].params.regexPattern).to.equal("*");
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.dealId).to.equal('the-deal-id');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].partnerTimeToRespond).to.equal(944);
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].clientLatencyTimeMs).to.equal(3214);
+
+
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.originalCpm).to.equal(1.52);
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.originalCurrency).to.equal('USD');
+
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.mi).to.equal('matched-impression');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.meta.advertiserDomains).to.deep.equal(['example.com']);
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.mediaType).to.equal('banner');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.floorData.floorRuleValue).to.equal(1.1);
+
+      expect(data.sd['/19968336/header-bid-tag-1'].bidWonAdId).to.equal('fake_ad_id_2');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.adserverTargeting.hb_pb).to.equal(1.5);
+
       let firstTracker = requests[1].url;
       expect(firstTracker.split('?')[0]).to.equal('https://t.pubmatic.com/wt');
       data = {};
       firstTracker.split('?')[1].split('&').map(e => e.split('=')).forEach(e => data[e[0]] = e[1]);
-      expect(data.kgpv).to.equal('*');
+      expect(data.v).to.equal('1');
+      expect(data.psrc).to.equal('web');
     });
 
-    it('Logger: regexPattern in bid.bidResponse', function() {
+   
+    it('Logger: regexPattern in bid.bidResponse', function () {
       const BID2_COPY = utils.deepClone(BID2);
       BID2_COPY.regexPattern = '*';
       events.emit(AUCTION_INIT, MOCK.AUCTION_INIT);
@@ -1301,44 +1123,53 @@ describe('pubmatic analytics adapter', function () {
       clock.tick(2000 + 1000);
       expect(requests.length).to.equal(3); // 1 logger and 2 win-tracker
       let request = requests[2]; // logger is executed late, trackers execute first
-      expect(request.url).to.equal('https://t.pubmatic.com/wl?pubid=9999');
+      expect(request.url).to.equal('https://t.pubmatic.com/wl?v=1&psrc=web');
       let data = getLoggerJsonFromRequest(request.requestBody);
-      expect(data.s[1].sn).to.equal('/19968336/header-bid-tag-1');
-      expect(data.s[1].sz).to.deep.equal(['1000x300', '970x250', '728x90']);
-      expect(data.s[1].sid).not.to.be.undefined;
-      expect(data.s[1].ps).to.be.an('array');
-      expect(data.s[1].ps.length).to.equal(1);
-      expect(data.s[1].ps[0].pn).to.equal('pubmatic');
-      expect(data.s[1].ps[0].bc).to.equal('pubmatic');
-      expect(data.s[1].ps[0].bidid).to.equal('3bd4ebb1c900e2');
-      expect(data.s[1].ps[0].db).to.equal(0);
-      expect(data.s[1].ps[0].kgpv).to.equal('*');
-      expect(data.s[1].ps[0].kgpsv).to.equal('this-is-a-kgpv');
-      expect(data.s[1].ps[0].psz).to.equal('728x90');
-      expect(data.s[1].ps[0].eg).to.equal(1.52);
-      expect(data.s[1].ps[0].en).to.equal(1.52);
-      expect(data.s[1].ps[0].di).to.equal('the-deal-id');
-      expect(data.s[1].ps[0].dc).to.equal('PMP');
-      expect(data.s[1].ps[0].mi).to.equal('matched-impression');
-      expect(data.s[1].ps[0].adv).to.equal('example.com');
-      expect(data.s[0].ps[0].l1).to.equal(944);
-      expect(data.s[0].ps[0].ol1).to.equal(3214);
-      expect(data.s[1].ps[0].l2).to.equal(0);
-      expect(data.s[1].ps[0].ss).to.equal(1);
-      expect(data.s[1].ps[0].t).to.equal(0);
-      expect(data.s[1].ps[0].wb).to.equal(0); // bidPriceUSD is not getting set as currency module is not added, so unable to set wb to 1
-      expect(data.s[1].ps[0].af).to.equal('banner');
-      expect(data.s[1].ps[0].ocpm).to.equal(1.52);
-      expect(data.s[1].ps[0].ocry).to.equal('USD');
+      // check mandatory fields
+      expect(data).to.have.property('sd');
+      expect(data).to.have.property('fd');
+      expect(data).to.have.property('rd');
+
+      expect(data.sd).to.have.property('/19968336/header-bid-tag-1');
+      expect(data.sd['/19968336/header-bid-tag-1'].dimensions).to.deep.equal([[1000, 300], [970, 250], [728, 90]]);
+      expect(data.sd['/19968336/header-bid-tag-1'].bids).to.have.property('3bd4ebb1c900e2');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].adapterCode).to.equal('pubmatic');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidderCode).to.equal('pubmatic');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0]).to.have.property('bidResponse');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidId).to.equal('3bd4ebb1c900e2');
+      expect(data.fd.flr.skipped).to.equal(false);
+
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.bidGrossCpmUSD).to.equal(1.52);
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.bidPriceUSD).to.equal(1.52);
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.dealId).to.equal('the-deal-id');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].partnerTimeToRespond).to.equal(944);
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].clientLatencyTimeMs).to.equal(3214);
+
+
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.originalCpm).to.equal(1.52);
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.originalCurrency).to.equal('USD');
+
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.regexPattern).to.equal('*');
+
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.mi).to.equal('matched-impression');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.meta.advertiserDomains).to.deep.equal(['example.com']);
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.mediaType).to.equal('banner');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.floorData.floorRuleValue).to.equal(1.1);
+
+      expect(data.sd['/19968336/header-bid-tag-1'].bidWonAdId).to.equal('fake_ad_id_2');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.adserverTargeting.hb_pb).to.equal(1.5);
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.dealChannel).to.equal('PMP');
+
       // respective tracker slot
       let firstTracker = requests[1].url;
       expect(firstTracker.split('?')[0]).to.equal('https://t.pubmatic.com/wt');
       data = {};
       firstTracker.split('?')[1].split('&').map(e => e.split('=')).forEach(e => data[e[0]] = e[1]);
-      expect(data.kgpv).to.equal('*');
+      expect(data.v).to.equal('1');
     });
 
-    it('Logger: to handle floor rejected bids', function() {
+    
+    it('Logger: to handle floor rejected bids', function () {
       this.timeout(5000)
 
       sandbox.stub($$PREBID_GLOBAL$$, 'getHighestCpmBids').callsFake((key) => {
@@ -1357,48 +1188,51 @@ describe('pubmatic analytics adapter', function () {
       clock.tick(2000 + 1000);
       expect(requests.length).to.equal(2); // 1 logger and 1 win-tracker
       let request = requests[1]; // logger is executed late, trackers execute first
-      expect(request.url).to.equal('https://t.pubmatic.com/wl?pubid=9999');
+      expect(request.url).to.equal('https://t.pubmatic.com/wl?v=1&psrc=web');
       let data = getLoggerJsonFromRequest(request.requestBody);
-      expect(data.ffs).to.equal(1);
-      expect(data.fsrc).to.equal(2);
-      expect(data.fp).to.equal('pubmatic');
+      // check mandatory fields
+      expect(data).to.have.property('sd');
+      expect(data).to.have.property('fd');
+      expect(data).to.have.property('rd');
 
-      // slot 2
-      // Testing only for rejected bid as other scenarios will be covered under other TCs
-      expect(data.s[1].sn).to.equal('/19968336/header-bid-tag-1');
-      expect(data.s[1].fskp).to.equal(0);
-      expect(data.s[1].sz).to.deep.equal(['1000x300', '970x250', '728x90']);
-      expect(data.s[1].sid).not.to.be.undefined;
-      expect(data.s[1].ps).to.be.an('array');
-      expect(data.s[1].ps.length).to.equal(1);
-      expect(data.s[1].ps[0].pn).to.equal('pubmatic');
-      expect(data.s[0].ps[0].bc).to.equal('pubmatic');
-      expect(data.s[1].ps[0].bidid).to.equal('3bd4ebb1c900e2');
-      expect(data.s[1].ps[0].origbidid).to.equal('partnerImpressionID-2');
-      expect(data.s[1].ps[0].db).to.equal(0);
-      expect(data.s[1].ps[0].kgpv).to.equal('this-is-a-kgpv');
-      expect(data.s[1].ps[0].kgpsv).to.equal('this-is-a-kgpv');
-      expect(data.s[1].ps[0].psz).to.equal('728x90');
-      expect(data.s[1].ps[0].eg).to.equal(1.52);
-      expect(data.s[1].ps[0].en).to.equal(0); // Net CPM is market as 0 due to bid rejection
-      expect(data.s[1].ps[0].di).to.equal('the-deal-id');
-      expect(data.s[1].ps[0].dc).to.equal('PMP');
-      expect(data.s[1].ps[0].mi).to.equal('matched-impression');
-      expect(data.s[1].ps[0].adv).to.equal('example.com');
-      expect(data.s[0].ps[0].l1).to.equal(944);
-      expect(data.s[0].ps[0].ol1).to.equal(3214);
-      expect(data.s[1].ps[0].l2).to.equal(0);
-      expect(data.s[1].ps[0].ss).to.equal(1);
-      expect(data.s[1].ps[0].t).to.equal(0);
-      expect(data.s[1].ps[0].wb).to.equal(1);
-      expect(data.s[1].ps[0].af).to.equal('banner');
-      expect(data.s[1].ps[0].ocpm).to.equal(1.52);
-      expect(data.s[1].ps[0].ocry).to.equal('USD');
-      expect(data.s[1].ps[0].frv).to.equal(1.1);
-      expect(data.s[1].ps[0].pb).to.equal(1.50);
+      expect(data.fd.flr.fetchStatus).to.equal('success');
+      expect(data.fd.flr).to.have.property('enforcements');
+      expect(data.fd.flr.floorProvider).to.equal('pubmatic');
+
+
+      expect(data.sd).to.have.property('/19968336/header-bid-tag-1');
+      expect(data.sd['/19968336/header-bid-tag-1'].dimensions).to.deep.equal([[1000, 300], [970, 250], [728, 90]]);
+      expect(data.sd['/19968336/header-bid-tag-1'].bids).to.have.property('3bd4ebb1c900e2');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].adapterCode).to.equal('pubmatic');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidderCode).to.equal('pubmatic');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0]).to.have.property('bidResponse');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidId).to.equal('3bd4ebb1c900e2');
+      expect(data.fd.flr.skipped).to.equal(false);
+
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.bidGrossCpmUSD).to.equal(1.52);
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.bidPriceUSD).to.equal(0);
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.dealId).to.equal('the-deal-id');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].partnerTimeToRespond).to.equal(944);
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].clientLatencyTimeMs).to.equal(3214);
+
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].partnerTimeToRespond).to.equal(944);
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].clientLatencyTimeMs).to.equal(3214);
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.originalCpm).to.equal(1.52);
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.originalCurrency).to.equal('USD');
+
+
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.mi).to.equal('matched-impression');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.meta.advertiserDomains).to.deep.equal(['example.com']);
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.mediaType).to.equal('banner');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.floorData.floorRuleValue).to.equal(1.1);
+
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.adserverTargeting.hb_pb).to.equal(1.5);
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.dealChannel).to.equal('PMP');
+
     });
 
-    it('Logger: best case + win tracker in case of Bidder Aliases', function() {
+    
+    it('Logger: best case + win tracker in case of Bidder Aliases', function () {
       MOCK.BID_REQUESTED['bids'][0]['bidder'] = 'pubmatic_alias';
       MOCK.BID_REQUESTED['bids'][0]['bidderCode'] = 'pubmatic_alias';
       adapterManager.aliasRegistry['pubmatic_alias'] = 'pubmatic';
@@ -1424,113 +1258,113 @@ describe('pubmatic analytics adapter', function () {
       clock.tick(2000 + 1000);
       expect(requests.length).to.equal(3); // 1 logger and 2 win-tracker
       let request = requests[2]; // logger is executed late, trackers execute first
-      expect(request.url).to.equal('https://t.pubmatic.com/wl?pubid=9999');
+      expect(request.url).to.equal('https://t.pubmatic.com/wl?v=1&psrc=web');
       let data = getLoggerJsonFromRequest(request.requestBody);
-      expect(data.pubid).to.equal('9999');
-      expect(data.pid).to.equal('1111');
-      expect(data.pdvid).to.equal('20');
-      expect(data.iid).to.equal('25c6d7f5-699a-4bfc-87c9-996f915341fa');
-      expect(data.to).to.equal('3000');
-      expect(data.purl).to.equal('http://www.test.com/page.html');
-      expect(data.orig).to.equal('www.test.com');
-      expect(data.tst).to.equal(1519767016);
-      expect(data.tgid).to.equal(15);
-      expect(data.fmv).to.equal('floorModelTest');
-      expect(data.pbv).to.equal('$prebid.version$' || '-1');
-      expect(data.ft).to.equal(1);
-      expect(data.s).to.be.an('array');
-      expect(data.s.length).to.equal(2);
-      expect(data.ffs).to.equal(1);
-      expect(data.fsrc).to.equal(2);
-      expect(data.fp).to.equal('pubmatic');
+      // check mandatory fields
+      expect(data).to.have.property('sd');
+      expect(data).to.have.property('fd');
+      expect(data).to.have.property('rd');
+
+      expect(data.rd.pubid).to.equal('9999');
+      expect(data.rd.pid).to.equal('1111');
+      expect(data.rd.pdvid).to.equal('20');
+      expect(data.rd.iid).to.equal('25c6d7f5-699a-4bfc-87c9-996f915341fa');
+      expect(data.rd.to).to.equal(3000);
+      expect(data.rd.purl).to.equal('http://www.test.com/page.html');
+      expect(data.rd.tst).to.equal(1519767016);
+      expect(data.rd.tgid).to.equal(15);
+
+      // floor data in featureList
+      expect(data.fd.flr.modelVersion).to.equal('floorModelTest');
+      expect(data.fd.flr).to.have.property('enforcements');
+      expect(data.fd.flr.enforcements).to.deep.equal({
+        enforceJS: true,
+        enforcePBS: false,
+        floorDeals: false,
+        bidAdjustment: true
+      });
+      expect(data.fd.flr.fetchStatus).to.equal('success');
+      expect(data.fd.flr.location).to.equal('fetch');
+      expect(data.fd.flr.skipRate).to.equal(0);
+      expect(data.fd.flr.skipped).to.equal(false);
+
+      expect(data.rd.pbv).to.equal('$prebid.version$' || '-1');
+      expect(data.sd).to.be.an('object');
+      expect(Object.keys(data.sd).length).to.equal(2);
+
 
       // slot 1
-      expect(data.s[0].sn).to.equal('/19968336/header-bid-tag-0');
-      expect(data.s[0].fskp).to.equal(0);
-      expect(data.s[0].sz).to.deep.equal(['640x480']);
-      expect(data.s[0].sid).not.to.be.undefined;
-      expect(data.s[0].ps).to.be.an('array');
-      expect(data.s[0].au).to.equal('/19968336/header-bid-tag-0');
-      expect(data.s[0].ps.length).to.equal(1);
-      expect(data.s[0].ps[0].pn).to.equal('pubmatic');
-      expect(data.s[0].ps[0].bc).to.equal('pubmatic_alias');
-      expect(data.s[0].ps[0].bidid).to.equal('2ecff0db240757');
-      expect(data.s[0].ps[0].origbidid).to.equal('partnerImpressionID-1');
-      expect(data.s[0].ps[0].db).to.equal(0);
-      expect(data.s[0].ps[0].kgpv).to.equal('/19968336/header-bid-tag-0');
-      expect(data.s[0].ps[0].kgpsv).to.equal('/19968336/header-bid-tag-0');
-      expect(data.s[0].ps[0].psz).to.equal('640x480');
-      expect(data.s[0].ps[0].eg).to.equal(1.23);
-      expect(data.s[0].ps[0].en).to.equal(1.23);
-      expect(data.s[0].ps[0].di).to.equal('-1');
-      expect(data.s[0].ps[0].dc).to.equal('');
-      expect(data.s[0].ps[0].l1).to.equal(944);
-      expect(data.s[0].ps[0].ol1).to.equal(3214);
-      expect(data.s[0].ps[0].l2).to.equal(0);
-      expect(data.s[0].ps[0].ss).to.equal(0);
-      expect(data.s[0].ps[0].t).to.equal(0);
-      expect(data.s[0].ps[0].wb).to.equal(1);
-      expect(data.s[0].ps[0].af).to.equal('video');
-      expect(data.s[0].ps[0].ocpm).to.equal(1.23);
-      expect(data.s[0].ps[0].ocry).to.equal('USD');
-      expect(data.s[0].ps[0].frv).to.equal(1.1);
-      expect(data.s[0].ps[0].pb).to.equal(1.2);
+
+      expect(data.sd).to.have.property('/19968336/header-bid-tag-0');
+
+      expect(data.sd['/19968336/header-bid-tag-0'].bids).to.have.property('2ecff0db240757');
+      expect(data.sd['/19968336/header-bid-tag-0'].dimensions).to.deep.equal([[640, 480]])
+      expect(data.sd['/19968336/header-bid-tag-0'].bids['2ecff0db240757'][0].adapterCode).to.equal('pubmatic');
+      expect(data.sd['/19968336/header-bid-tag-0'].bids['2ecff0db240757'][0].bidderCode).to.equal('pubmatic_alias');
+      expect(data.sd['/19968336/header-bid-tag-0'].bids['2ecff0db240757'][0].bidResponse.originalCpm).to.equal(1.23);
+      expect(data.sd['/19968336/header-bid-tag-0'].bids['2ecff0db240757'][0].bidResponse.originalCurrency).to.equal('USD');
+
+
+      expect(data.sd['/19968336/header-bid-tag-0'].bids['2ecff0db240757'][0]).to.have.property('bidResponse');
+      expect(data.sd['/19968336/header-bid-tag-0'].bids['2ecff0db240757'][0].bidId).to.equal('2ecff0db240757');
+      expect(data.fd.flr.skipped).to.equal(false);
+
+      expect(data.sd['/19968336/header-bid-tag-0'].bids['2ecff0db240757'][0].bidResponse.bidGrossCpmUSD).to.equal(1.23);
+      expect(data.sd['/19968336/header-bid-tag-0'].bids['2ecff0db240757'][0].bidResponse.bidPriceUSD).to.equal(1.23);
+      expect(data.sd['/19968336/header-bid-tag-0'].bids['2ecff0db240757'][0].partnerTimeToRespond).to.equal(944);
+      expect(data.sd['/19968336/header-bid-tag-0'].bids['2ecff0db240757'][0].clientLatencyTimeMs).to.equal(3214);
+
+
+      expect(data.sd['/19968336/header-bid-tag-0'].bids['2ecff0db240757'][0].bidResponse.originalCpm).to.equal(1.23);
+      expect(data.sd['/19968336/header-bid-tag-0'].bids['2ecff0db240757'][0].bidResponse.originalCurrency).to.equal('USD');
+
+      expect(data.sd['/19968336/header-bid-tag-0'].bids['2ecff0db240757'][0].bidResponse.mediaType).to.equal('video');
+      expect(data.sd['/19968336/header-bid-tag-0'].bids['2ecff0db240757'][0].bidResponse.floorData.floorRuleValue).to.equal(1.1);
+
+      expect(data.sd['/19968336/header-bid-tag-0'].bidWonAdId).to.equal('fake_ad_id');
+      expect(data.sd['/19968336/header-bid-tag-0'].bids['2ecff0db240757'][0].bidResponse.adserverTargeting.hb_pb).to.equal(1.2);
+
 
       // slot 2
-      expect(data.s[1].sn).to.equal('/19968336/header-bid-tag-1');
-      expect(data.s[1].fskp).to.equal(0);
-      expect(data.s[1].sz).to.deep.equal(['1000x300', '970x250', '728x90']);
-      expect(data.s[1].sid).not.to.be.undefined;
-      expect(data.s[1].ps).to.be.an('array');
-      expect(data.s[1].ps.length).to.equal(1);
-      expect(data.s[1].ps[0].pn).to.equal('pubmatic');
-      expect(data.s[1].ps[0].bc).to.equal('pubmatic');
-      expect(data.s[1].ps[0].bidid).to.equal('3bd4ebb1c900e2');
-      expect(data.s[1].ps[0].origbidid).to.equal('partnerImpressionID-2');
-      expect(data.s[1].ps[0].db).to.equal(0);
-      expect(data.s[1].ps[0].kgpv).to.equal('this-is-a-kgpv');
-      expect(data.s[1].ps[0].kgpsv).to.equal('this-is-a-kgpv');
-      expect(data.s[1].ps[0].psz).to.equal('728x90');
-      expect(data.s[1].ps[0].eg).to.equal(1.52);
-      expect(data.s[1].ps[0].en).to.equal(1.52);
-      expect(data.s[1].ps[0].di).to.equal('the-deal-id');
-      expect(data.s[1].ps[0].dc).to.equal('PMP');
-      expect(data.s[1].ps[0].mi).to.equal('matched-impression');
-      expect(data.s[1].ps[0].adv).to.equal('example.com');
-      expect(data.s[0].ps[0].l1).to.equal(944);
-      expect(data.s[0].ps[0].ol1).to.equal(3214);
-      expect(data.s[1].ps[0].l2).to.equal(0);
-      expect(data.s[1].ps[0].ss).to.equal(1);
-      expect(data.s[1].ps[0].t).to.equal(0);
-      expect(data.s[1].ps[0].wb).to.equal(1);
-      expect(data.s[1].ps[0].af).to.equal('banner');
-      expect(data.s[1].ps[0].ocpm).to.equal(1.52);
-      expect(data.s[1].ps[0].ocry).to.equal('USD');
-      expect(data.s[1].ps[0].frv).to.equal(1.1);
-      expect(data.s[1].ps[0].pb).to.equal(1.50);
+      expect(data.sd).to.have.property('/19968336/header-bid-tag-1');
+      expect(data.sd['/19968336/header-bid-tag-1'].dimensions).to.deep.equal([[1000, 300], [970, 250], [728, 90]]);
+      expect(data.sd['/19968336/header-bid-tag-1'].bids).to.have.property('3bd4ebb1c900e2');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].adapterCode).to.equal('pubmatic');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidderCode).to.equal('pubmatic');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0]).to.have.property('bidResponse');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidId).to.equal('3bd4ebb1c900e2');
+      expect(data.fd.flr.skipped).to.equal(false);
+
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.bidGrossCpmUSD).to.equal(1.52);
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.bidPriceUSD).to.equal(1.52);
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].params.kgpv).to.equal("this-is-a-kgpv");
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.dealId).to.equal('the-deal-id');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].partnerTimeToRespond).to.equal(944);
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].clientLatencyTimeMs).to.equal(3214);
+
+
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.originalCpm).to.equal(1.52);
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.originalCurrency).to.equal('USD');
+
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.mi).to.equal('matched-impression');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.meta.advertiserDomains).to.deep.equal(['example.com']);
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.mediaType).to.equal('banner');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.floorData.floorRuleValue).to.equal(1.1);
+
+      expect(data.sd['/19968336/header-bid-tag-1'].bidWonAdId).to.equal('fake_ad_id_2');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.adserverTargeting.hb_pb).to.equal(1.5);
 
       // tracker slot1
       let firstTracker = requests[0].url;
       expect(firstTracker.split('?')[0]).to.equal('https://t.pubmatic.com/wt');
       data = {};
       firstTracker.split('?')[1].split('&').map(e => e.split('=')).forEach(e => data[e[0]] = e[1]);
-      expect(data.pubid).to.equal('9999');
-      expect(decodeURIComponent(data.purl)).to.equal('http://www.test.com/page.html');
-      expect(data.tst).to.equal('1519767014');
-      expect(data.iid).to.equal('25c6d7f5-699a-4bfc-87c9-996f915341fa');
-      expect(data.bidid).to.equal('2ecff0db240757');
-      expect(data.pid).to.equal('1111');
-      expect(data.pdvid).to.equal('20');
-      expect(decodeURIComponent(data.slot)).to.equal('/19968336/header-bid-tag-0');
-      expect(decodeURIComponent(data.kgpv)).to.equal('/19968336/header-bid-tag-0');
-      expect(data.pn).to.equal('pubmatic');
-      expect(data.bc).to.equal('pubmatic_alias');
-      expect(data.eg).to.equal('1.23');
-      expect(data.en).to.equal('1.23');
-      expect(data.origbidid).to.equal('partnerImpressionID-1');
+      expect(data.v).to.equal('1');
+      expect(data.psrc).to.equal('web');
+
     });
 
-    it('Logger: best case + win tracker in case of GroupM as alternate bidder', function() {
+    it('Logger: best case + win tracker in case of GroupM as alternate bidder', function () {
       MOCK.BID_REQUESTED['bids'][0]['bidderCode'] = 'groupm';
       sandbox.stub($$PREBID_GLOBAL$$, 'getHighestCpmBids').callsFake((key) => {
         return [MOCK.BID_RESPONSE[0], MOCK.BID_RESPONSE[1]]
@@ -1553,255 +1387,109 @@ describe('pubmatic analytics adapter', function () {
       clock.tick(2000 + 1000);
       expect(requests.length).to.equal(3); // 1 logger and 2 win-tracker
       let request = requests[2]; // logger is executed late, trackers execute first
-      expect(request.url).to.equal('https://t.pubmatic.com/wl?pubid=9999');
+      expect(request.url).to.equal('https://t.pubmatic.com/wl?v=1&psrc=web');
       let data = getLoggerJsonFromRequest(request.requestBody);
-      expect(data.pubid).to.equal('9999');
-      expect(data.pid).to.equal('1111');
-      expect(data.pdvid).to.equal('20');
-      expect(data.iid).to.equal('25c6d7f5-699a-4bfc-87c9-996f915341fa');
-      expect(data.to).to.equal('3000');
-      expect(data.purl).to.equal('http://www.test.com/page.html');
-      expect(data.orig).to.equal('www.test.com');
-      expect(data.tst).to.equal(1519767016);
-      expect(data.tgid).to.equal(15);
-      expect(data.fmv).to.equal('floorModelTest');
-      expect(data.pbv).to.equal('$prebid.version$' || '-1');
-      expect(data.ft).to.equal(1);
-      expect(data.s).to.be.an('array');
-      expect(data.s.length).to.equal(2);
-      expect(data.ffs).to.equal(1);
-      expect(data.fsrc).to.equal(2);
-      expect(data.fp).to.equal('pubmatic');
+      // check mandatory fields
+      expect(data).to.have.property('sd');
+      expect(data).to.have.property('fd');
+      expect(data).to.have.property('rd');
+      
+      expect(data.rd.pubid).to.equal('9999');
+      expect(data.rd.pid).to.equal('1111');
+      expect(data.rd.pdvid).to.equal('20');
+      expect(data.rd.iid).to.equal('25c6d7f5-699a-4bfc-87c9-996f915341fa');
+      expect(data.rd.to).to.equal(3000);
+      expect(data.rd.purl).to.equal('http://www.test.com/page.html');
+      expect(data.rd.tst).to.equal(1519767016);
+      expect(data.rd.tgid).to.equal(15);
 
-      // slot 1
-      expect(data.s[0].sn).to.equal('/19968336/header-bid-tag-0');
-      expect(data.s[0].fskp).to.equal(0);
-      expect(data.s[0].sz).to.deep.equal(['640x480']);
-      expect(data.s[0].sid).not.to.be.undefined;
-      expect(data.s[0].ps).to.be.an('array');
-      expect(data.s[0].au).to.equal('/19968336/header-bid-tag-0');
-      expect(data.s[0].ps.length).to.equal(1);
-      expect(data.s[0].ps[0].pn).to.equal('pubmatic');
-      expect(data.s[0].ps[0].bc).to.equal('groupm');
-      expect(data.s[0].ps[0].bidid).to.equal('2ecff0db240757');
-      expect(data.s[0].ps[0].origbidid).to.equal('partnerImpressionID-1');
-      expect(data.s[0].ps[0].db).to.equal(0);
-      expect(data.s[0].ps[0].kgpv).to.equal('/19968336/header-bid-tag-0');
-      expect(data.s[0].ps[0].kgpsv).to.equal('/19968336/header-bid-tag-0');
-      expect(data.s[0].ps[0].psz).to.equal('640x480');
-      expect(data.s[0].ps[0].eg).to.equal(1.23);
-      expect(data.s[0].ps[0].en).to.equal(1.23);
-      expect(data.s[0].ps[0].di).to.equal('-1');
-      expect(data.s[0].ps[0].dc).to.equal('');
-      expect(data.s[0].ps[0].l1).to.equal(944);
-      expect(data.s[0].ps[0].ol1).to.equal(3214);
-      expect(data.s[0].ps[0].l2).to.equal(0);
-      expect(data.s[0].ps[0].ss).to.equal(0);
-      expect(data.s[0].ps[0].t).to.equal(0);
-      expect(data.s[0].ps[0].wb).to.equal(1);
-      expect(data.s[0].ps[0].af).to.equal('video');
-      expect(data.s[0].ps[0].ocpm).to.equal(1.23);
-      expect(data.s[0].ps[0].ocry).to.equal('USD');
-      expect(data.s[0].ps[0].frv).to.equal(1.1);
-      expect(data.s[0].ps[0].pb).to.equal(1.2);
+      // floor data in feature list data
+      expect(data.fd.flr.modelVersion).to.equal('floorModelTest');
+      expect(data.fd.flr).to.have.property('enforcements');
+      expect(data.fd.flr.enforcements).to.deep.equal({
+        enforceJS: true,
+        enforcePBS: false,
+        floorDeals: false,
+        bidAdjustment: true
+      });
+      expect(data.fd.flr.fetchStatus).to.equal('success');
+      expect(data.fd.flr.floorProvider).to.equal('pubmatic');
+      expect(data.fd.flr.location).to.equal('fetch');
+      expect(data.fd.flr.skipRate).to.equal(0);
+      expect(data.fd.flr.skipped).to.equal(false);
+
+      expect(data.rd.pbv).to.equal('$prebid.version$' || '-1');
+
+      expect(data.sd).to.be.an('object');
+      expect(Object.keys(data.sd).length).to.equal(2);
+
+      expect(data.sd).to.have.property('/19968336/header-bid-tag-0');
+
+      expect(data.sd['/19968336/header-bid-tag-0'].bids).to.have.property('2ecff0db240757');
+      expect(data.sd['/19968336/header-bid-tag-0'].dimensions).to.deep.equal([[640, 480]])
+      expect(data.sd['/19968336/header-bid-tag-0'].bids['2ecff0db240757'][0].adapterCode).to.equal('pubmatic');
+      expect(data.sd['/19968336/header-bid-tag-0'].bids['2ecff0db240757'][0].bidderCode).to.equal('groupm');
+      expect(data.sd['/19968336/header-bid-tag-0'].bids['2ecff0db240757'][0].bidResponse.originalCpm).to.equal(1.23);
+      expect(data.sd['/19968336/header-bid-tag-0'].bids['2ecff0db240757'][0].bidResponse.originalCurrency).to.equal('USD');
+
+
+      expect(data.sd['/19968336/header-bid-tag-0'].bids['2ecff0db240757'][0]).to.have.property('bidResponse');
+      expect(data.sd['/19968336/header-bid-tag-0'].bids['2ecff0db240757'][0].bidId).to.equal('2ecff0db240757');
+      expect(data.fd.flr.skipped).to.equal(false);
+
+      expect(data.sd['/19968336/header-bid-tag-0'].bids['2ecff0db240757'][0].bidResponse.bidGrossCpmUSD).to.equal(1.23);
+      expect(data.sd['/19968336/header-bid-tag-0'].bids['2ecff0db240757'][0].bidResponse.bidPriceUSD).to.equal(1.23);
+      expect(data.sd['/19968336/header-bid-tag-0'].bids['2ecff0db240757'][0].partnerTimeToRespond).to.equal(944);
+      expect(data.sd['/19968336/header-bid-tag-0'].bids['2ecff0db240757'][0].clientLatencyTimeMs).to.equal(3214);
+
+
+      expect(data.sd['/19968336/header-bid-tag-0'].bids['2ecff0db240757'][0].bidResponse.originalCpm).to.equal(1.23);
+      expect(data.sd['/19968336/header-bid-tag-0'].bids['2ecff0db240757'][0].bidResponse.originalCurrency).to.equal('USD');
+
+      expect(data.sd['/19968336/header-bid-tag-0'].bids['2ecff0db240757'][0].bidResponse.mediaType).to.equal('video');
+      expect(data.sd['/19968336/header-bid-tag-0'].bids['2ecff0db240757'][0].bidResponse.floorData.floorRuleValue).to.equal(1.1);
+
+      expect(data.sd['/19968336/header-bid-tag-0'].bidWonAdId).to.equal('fake_ad_id');
+      expect(data.sd['/19968336/header-bid-tag-0'].bids['2ecff0db240757'][0].bidResponse.adserverTargeting.hb_pb).to.equal(1.2);
+
 
       // slot 2
-      expect(data.s[1].sn).to.equal('/19968336/header-bid-tag-1');
-      expect(data.s[1].sz).to.deep.equal(['1000x300', '970x250', '728x90']);
-      expect(data.s[1].sid).not.to.be.undefined;
-      expect(data.s[1].ps).to.be.an('array');
-      expect(data.s[1].ps.length).to.equal(1);
-      expect(data.s[1].ps[0].pn).to.equal('pubmatic');
-      expect(data.s[1].ps[0].bc).to.equal('pubmatic');
-      expect(data.s[1].ps[0].bidid).to.equal('3bd4ebb1c900e2');
-      expect(data.s[1].ps[0].origbidid).to.equal('partnerImpressionID-2');
-      expect(data.s[1].ps[0].db).to.equal(0);
-      expect(data.s[1].ps[0].kgpv).to.equal('this-is-a-kgpv');
-      expect(data.s[1].ps[0].kgpsv).to.equal('this-is-a-kgpv');
-      expect(data.s[1].ps[0].psz).to.equal('728x90');
-      expect(data.s[1].ps[0].eg).to.equal(1.52);
-      expect(data.s[1].ps[0].en).to.equal(1.52);
-      expect(data.s[1].ps[0].di).to.equal('the-deal-id');
-      expect(data.s[1].ps[0].dc).to.equal('PMP');
-      expect(data.s[1].ps[0].mi).to.equal('matched-impression');
-      expect(data.s[1].ps[0].adv).to.equal('example.com');
-      expect(data.s[0].ps[0].l1).to.equal(944);
-      expect(data.s[0].ps[0].ol1).to.equal(3214);
-      expect(data.s[1].ps[0].l2).to.equal(0);
-      expect(data.s[1].ps[0].ss).to.equal(1);
-      expect(data.s[1].ps[0].t).to.equal(0);
-      expect(data.s[1].ps[0].wb).to.equal(1);
-      expect(data.s[1].ps[0].af).to.equal('banner');
-      expect(data.s[1].ps[0].ocpm).to.equal(1.52);
-      expect(data.s[1].ps[0].ocry).to.equal('USD');
+      expect(data.sd).to.have.property('/19968336/header-bid-tag-1');
+      expect(data.sd['/19968336/header-bid-tag-1'].dimensions).to.deep.equal([[1000, 300], [970, 250], [728, 90]]);
+      expect(data.sd['/19968336/header-bid-tag-1'].bids).to.have.property('3bd4ebb1c900e2');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].adapterCode).to.equal('pubmatic');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidderCode).to.equal('pubmatic');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0]).to.have.property('bidResponse');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidId).to.equal('3bd4ebb1c900e2');
+      expect(data.fd.flr.skipped).to.equal(false);
 
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.bidGrossCpmUSD).to.equal(1.52);
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.bidPriceUSD).to.equal(1.52);
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].params.kgpv).to.equal("this-is-a-kgpv");
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.dealId).to.equal('the-deal-id');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].partnerTimeToRespond).to.equal(944);
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].clientLatencyTimeMs).to.equal(3214);
+
+
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.originalCpm).to.equal(1.52);
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.originalCurrency).to.equal('USD');
+
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.mi).to.equal('matched-impression');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.meta.advertiserDomains).to.deep.equal(['example.com']);
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.mediaType).to.equal('banner');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.floorData.floorRuleValue).to.equal(1.1);
+
+      expect(data.sd['/19968336/header-bid-tag-1'].bidWonAdId).to.equal('fake_ad_id_2');
+      expect(data.sd['/19968336/header-bid-tag-1'].bids['3bd4ebb1c900e2'][0].bidResponse.adserverTargeting.hb_pb).to.equal(1.5);
+
+   
       // tracker slot1
       let firstTracker = requests[0].url;
       expect(firstTracker.split('?')[0]).to.equal('https://t.pubmatic.com/wt');
       data = {};
       firstTracker.split('?')[1].split('&').map(e => e.split('=')).forEach(e => data[e[0]] = e[1]);
-      expect(data.pubid).to.equal('9999');
-      expect(decodeURIComponent(data.purl)).to.equal('http://www.test.com/page.html');
-      expect(data.tst).to.equal('1519767014');
-      expect(data.iid).to.equal('25c6d7f5-699a-4bfc-87c9-996f915341fa');
-      expect(data.bidid).to.equal('2ecff0db240757');
-      expect(data.pid).to.equal('1111');
-      expect(data.pdvid).to.equal('20');
-      expect(decodeURIComponent(data.slot)).to.equal('/19968336/header-bid-tag-0');
-      expect(decodeURIComponent(data.kgpv)).to.equal('/19968336/header-bid-tag-0');
-      expect(data.pn).to.equal('pubmatic');
-      expect(data.bc).to.equal('groupm');
-      expect(data.eg).to.equal('1.23');
-      expect(data.en).to.equal('1.23');
-      expect(data.origbidid).to.equal('partnerImpressionID-1');
-    });
-
-    it('Logger: should use originalRequestId to find the bid', function() {
-      MOCK.BID_RESPONSE[1]['originalRequestId'] = '3bd4ebb1c900e2';
-      MOCK.BID_RESPONSE[1]['requestId'] = '54d4ebb1c9003e';
-      sandbox.stub($$PREBID_GLOBAL$$, 'getHighestCpmBids').callsFake((key) => {
-        return [MOCK.BID_RESPONSE[0], MOCK.BID_RESPONSE[1]]
-      });
-
-      config.setConfig({
-        testGroupId: 15
-      });
-
-      events.emit(AUCTION_INIT, MOCK.AUCTION_INIT);
-      events.emit(BID_REQUESTED, MOCK.BID_REQUESTED);
-      events.emit(BID_RESPONSE, MOCK.BID_RESPONSE[0]);
-      events.emit(BID_RESPONSE, MOCK.BID_RESPONSE[1]);
-      events.emit(BIDDER_DONE, MOCK.BIDDER_DONE);
-      events.emit(AUCTION_END, MOCK.AUCTION_END);
-      events.emit(SET_TARGETING, MOCK.SET_TARGETING);
-      events.emit(BID_WON, MOCK.BID_WON[0]);
-      events.emit(BID_WON, MOCK.BID_WON[1]);
-
-      clock.tick(2000 + 1000);
-      expect(requests.length).to.equal(3); // 1 logger and 2 win-tracker
-      let request = requests[2]; // logger is executed late, trackers execute first
-      expect(request.url).to.equal('https://t.pubmatic.com/wl?pubid=9999');
-      let data = getLoggerJsonFromRequest(request.requestBody);
-      expect(data.s).to.be.an('array');
-      expect(data.s.length).to.equal(2);
-
-      // slot 1
-      expect(data.s[0].ps[0].bidid).to.equal('2ecff0db240757');
-      expect(data.s[0].ps[0].origbidid).to.equal('partnerImpressionID-1');
-
-      // slot 2
-      expect(data.s[1].ps[0].bidid).to.equal('54d4ebb1c9003e');
-      expect(data.s[1].ps[0].origbidid).to.equal('partnerImpressionID-2');
-
-      // tracker slot1
-      let firstTracker = requests[0].url;
-      expect(firstTracker.split('?')[0]).to.equal('https://t.pubmatic.com/wt');
-      data = {};
-      firstTracker.split('?')[1].split('&').map(e => e.split('=')).forEach(e => data[e[0]] = e[1]);
-      expect(data.bidid).to.equal('2ecff0db240757');
-      expect(data.origbidid).to.equal('partnerImpressionID-1');
-    });
-
-    it('Logger: best case + win tracker. Log bidId when partnerimpressionid is missing', function() {
-      delete MOCK.BID_RESPONSE[1]['partnerImpId'];
-      MOCK.BID_RESPONSE[1]['requestId'] = '3bd4ebb1c900e2';
-      MOCK.BID_RESPONSE[1]['prebidBidId'] = 'Prebid-bid-id-1';
-      sandbox.stub($$PREBID_GLOBAL$$, 'getHighestCpmBids').callsFake((key) => {
-        return [MOCK.BID_RESPONSE[0], MOCK.BID_RESPONSE[1]]
-      });
-
-      config.setConfig({
-        testGroupId: 15
-      });
-
-      events.emit(AUCTION_INIT, MOCK.AUCTION_INIT);
-      events.emit(BID_REQUESTED, MOCK.BID_REQUESTED);
-      events.emit(BID_RESPONSE, MOCK.BID_RESPONSE[0]);
-      events.emit(BID_RESPONSE, MOCK.BID_RESPONSE[1]);
-      events.emit(BIDDER_DONE, MOCK.BIDDER_DONE);
-      events.emit(AUCTION_END, MOCK.AUCTION_END);
-      events.emit(SET_TARGETING, MOCK.SET_TARGETING);
-      events.emit(BID_WON, MOCK.BID_WON[0]);
-      events.emit(BID_WON, MOCK.BID_WON[1]);
-
-      clock.tick(2000 + 1000);
-      expect(requests.length).to.equal(3); // 1 logger and 2 win-tracker
-      let request = requests[2]; // logger is executed late, trackers execute first
-      expect(request.url).to.equal('https://t.pubmatic.com/wl?pubid=9999');
-      let data = getLoggerJsonFromRequest(request.requestBody);
-      expect(data.s).to.be.an('array');
-      expect(data.s.length).to.equal(2);
-
-      // slot 1
-      expect(data.s[0].ps[0].bidid).to.equal('2ecff0db240757');
-      expect(data.s[0].ps[0].origbidid).to.equal('partnerImpressionID-1');
-
-      // slot 2
-      expect(data.s[1].ps[0].bidid).to.equal('3bd4ebb1c900e2');
-      expect(data.s[1].ps[0].origbidid).to.equal('3bd4ebb1c900e2');
-
-      // tracker slot1
-      let firstTracker = requests[0].url;
-      expect(firstTracker.split('?')[0]).to.equal('https://t.pubmatic.com/wt');
-      data = {};
-      firstTracker.split('?')[1].split('&').map(e => e.split('=')).forEach(e => data[e[0]] = e[1]);
-      expect(data.bidid).to.equal('2ecff0db240757');
-      expect(data.origbidid).to.equal('partnerImpressionID-1');
-    });
-  });
-
-  describe('Get Metadata function', function () {
-    it('should get the metadata object', function () {
-      const meta = {
-        networkId: 'nwid',
-        advertiserId: 'adid',
-        networkName: 'nwnm',
-        primaryCatId: 'pcid',
-        advertiserName: 'adnm',
-        agencyId: 'agid',
-        agencyName: 'agnm',
-        brandId: 'brid',
-        brandName: 'brnm',
-        dchain: 'dc',
-        demandSource: 'ds',
-        secondaryCatIds: ['secondaryCatIds']
-      };
-      const metadataObj = getMetadata(meta);
-
-      expect(metadataObj.nwid).to.equal('nwid');
-      expect(metadataObj.adid).to.equal('adid');
-      expect(metadataObj.nwnm).to.equal('nwnm');
-      expect(metadataObj.pcid).to.equal('pcid');
-      expect(metadataObj.adnm).to.equal('adnm');
-      expect(metadataObj.agid).to.equal('agid');
-      expect(metadataObj.agnm).to.equal('agnm');
-      expect(metadataObj.brid).to.equal('brid');
-      expect(metadataObj.brnm).to.equal('brnm');
-      expect(metadataObj.dc).to.equal('dc');
-      expect(metadataObj.ds).to.equal('ds');
-      expect(metadataObj.scids).to.be.an('array').with.length.above(0);
-      expect(metadataObj.scids[0]).to.equal('secondaryCatIds');
-    });
-
-    it('should return undefined if meta is null', function () {
-      const meta = null;
-      const metadataObj = getMetadata(meta);
-      expect(metadataObj).to.equal(undefined);
-    });
-
-    it('should return undefined if meta is a empty object', function () {
-      const meta = {};
-      const metadataObj = getMetadata(meta);
-      expect(metadataObj).to.equal(undefined);
-    });
-
-    it('should return undefined if meta object has different properties', function () {
-      const meta = {
-        a: 123,
-        b: 456
-      };
-      const metadataObj = getMetadata(meta);
-      expect(metadataObj).to.equal(undefined);
+      expect(data.v).to.equal('1');
+      expect(data.psrc).to.equal('web');
     });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
